### PR TITLE
第三方 provider 接入修复 + 许愿模式/shell展开/配置统一

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -49,7 +49,9 @@ jobs:
           # runner is queue-starved and the x64 cross-compile is unreliable, so it is dropped.
           mac='{"host":"macos-14","target":"mac-arm64","platform_flag":"--mac --arm64","group":"mac"}'
           linux='{"host":"ubuntu-24.04","target":"linux-x64","platform_flag":"--linux --x64","group":"linux"},{"host":"ubuntu-24.04-arm","target":"linux-arm64","platform_flag":"--linux --arm64","group":"linux"}'
-          win='{"host":"windows-2025","target":"win-x64","platform_flag":"--win --x64","group":"win"}'
+          # Windows arm64 builds natively on the GA windows-11-arm runner (no cross-compile);
+          # both native deps ship win32-arm64 prebuilds (@lydell/node-pty, @parcel/watcher).
+          win='{"host":"windows-2025","target":"win-x64","platform_flag":"--win --x64","group":"win"},{"host":"windows-11-arm","target":"win-arm64","platform_flag":"--win --arm64","group":"win"}'
           case "$PLATFORMS" in
             mac)       items="$mac" ;;
             linux)     items="$linux" ;;

--- a/packages/app/src/components/dialog-select-provider.tsx
+++ b/packages/app/src/components/dialog-select-provider.tsx
@@ -37,7 +37,7 @@ export const DialogSelectProvider: Component = () => {
           language.locale()
           return [
             { id: CUSTOM_ID, name: customLabel() },
-            ...Array.from(providers.all().values()).filter((provider) => popularProviders.includes(provider.id)),
+            ...Array.from(providers.all().values()),
           ]
         }}
         filterKeys={["id", "name"]}

--- a/packages/app/src/components/prompt-input/scenario-override.test.ts
+++ b/packages/app/src/components/prompt-input/scenario-override.test.ts
@@ -32,12 +32,24 @@ describe("scenario override (D1/D3)", () => {
     expect(resolveScenarioOverride("ses_new", "dir_x")).toBe("direct")
   })
 
-  test("stop resets both session and directory keys to direct (fail-safe)", () => {
+  test("stop clears both session and directory overrides so the next turn uses the configured default", () => {
     setScenarioOverride("ses_d", "wish")
     setScenarioOverride("dir_d", "wish")
     resetScenarioOnStop("ses_d", "dir_d")
-    expect(getScenarioOverride("ses_d")).toBe("direct")
-    expect(getScenarioOverride("dir_d")).toBe("direct")
+    // Cleared, not pinned to "direct": resolution now falls through to the configured default,
+    // and a pinned session key can no longer shadow a later dir-key toggle back to wish.
+    expect(getScenarioOverride("ses_d")).toBeUndefined()
+    expect(getScenarioOverride("dir_d")).toBeUndefined()
+    expect(resolveScenarioOverride("ses_d", "dir_d")).toBeUndefined()
+  })
+
+  test("after stop, re-toggling wish on the directory key re-engages wish at submit time", () => {
+    // Repro of the 'exit wish -> can never re-enter' bug: previously stop pinned the SESSION key to
+    // "direct", which submit resolves before the dir key, so the toggle (dir key only) was shadowed.
+    setScenarioOverride("ses_f", "wish")
+    resetScenarioOnStop("ses_f", "dir_f")
+    setScenarioOverride("dir_f", "wish") // user re-selects wish via the toggle
+    expect(resolveScenarioOverride("ses_f", "dir_f")).toBe("wish")
   })
 
   test("listeners are notified when overrides change", () => {

--- a/packages/app/src/components/prompt-input/scenario-override.ts
+++ b/packages/app/src/components/prompt-input/scenario-override.ts
@@ -1,6 +1,8 @@
 // D1/D3: scenario-mode override, set by the send-adjacent scenario toggle (D1).
-// It overrides the configured promptMode for a turn. Reset to `direct` on stop (D3) so any
-// interrupt returns to the fail-safe mode until the user re-engages wish.
+// It overrides the configured promptMode for a turn. Cleared on stop (D3) so the override is
+// strictly per-turn: once a turn ends, resolution falls back to the configured default (e.g. wish)
+// rather than being pinned to a stale value. The next turn re-enters the configured scenario unless
+// the user toggles again.
 //
 // Keys: the toggle writes a DIRECTORY-scoped key (stable before a session exists, e.g. on the
 // new-session composer); submit reads the SESSION key first, then falls back to the directory
@@ -34,10 +36,13 @@ export const getScenarioOverride = (key: string): ScenarioOverride | undefined =
 export const resolveScenarioOverride = (sessionKey: string, dirKey: string): ScenarioOverride | undefined =>
   scenarioOverride.get(sessionKey) ?? scenarioOverride.get(dirKey)
 
-// D3: any stop resets the scenario to `direct` (fail-safe) for both the session and its directory
-// scope, so the next user message is a plain direct submission until they re-engage wish.
+// D3: any stop CLEARS the per-turn override for both the session and its directory scope. Clearing
+// (not pinning "direct") is deliberate: a pinned "direct" would permanently shadow the configured
+// default and, because submit resolves the session key before the dir key, the toggle (which only
+// writes the dir key) could never re-engage wish. After clearing, the next turn falls back to the
+// configured scenario default.
 export const resetScenarioOnStop = (sessionKey: string, dirKey?: string): void => {
-  scenarioOverride.set(sessionKey, "direct")
-  if (dirKey) scenarioOverride.set(dirKey, "direct")
+  scenarioOverride.delete(sessionKey)
+  if (dirKey) scenarioOverride.delete(dirKey)
   notifyScenarioOverrideListeners()
 }

--- a/packages/app/src/components/settings-providers.tsx
+++ b/packages/app/src/components/settings-providers.tsx
@@ -51,7 +51,6 @@ const SettingsProvidersContent: Component = () => {
     return providers
       .connected()
       .filter((p) => p.id !== DEEPAGENT_PROVIDER_ID)
-      .filter((p) => popularProviders.includes(p.id) || isConfigCustom(p.id))
   })
 
   const popular = createMemo(() => {

--- a/packages/app/src/components/settings-v2/providers.tsx
+++ b/packages/app/src/components/settings-v2/providers.tsx
@@ -45,7 +45,6 @@ export const SettingsProvidersV2: Component = () => {
     return providers
       .connected()
       .filter((p) => p.id !== DEEPAGENT_PROVIDER_ID)
-      .filter((p) => popularProviders.includes(p.id) || isConfigCustom(p.id))
   })
 
   const configErrors = createMemo(() => providers.errors())

--- a/packages/app/src/context/models.tsx
+++ b/packages/app/src/context/models.tsx
@@ -3,7 +3,7 @@ import { createStore } from "solid-js/store"
 import { DateTime } from "luxon"
 import { filter, firstBy, flat, groupBy, mapValues, pipe, uniqueBy, values } from "remeda"
 import { createSimpleContext } from "@deepagent-code/ui/context"
-import { isVisibleProvider, useProviders } from "@/hooks/use-providers"
+import { useProviders } from "@/hooks/use-providers"
 import { Persist, persisted } from "@/utils/persist"
 
 export type ModelKey = { providerID: string; modelID: string }
@@ -98,7 +98,7 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
         ...m,
         name: m.name.replace("(latest)", "").trim(),
         latest: m.name.includes("(latest)"),
-      })).filter((m) => isVisibleProvider(m.provider)),
+      })),
     )
 
     const find = (key: ModelKey) => list().find((m) => m.id === key.modelID && m.provider.id === key.providerID)

--- a/packages/app/src/hooks/use-providers.ts
+++ b/packages/app/src/hooks/use-providers.ts
@@ -11,9 +11,6 @@ export const popularProviders = [
 ]
 const popularProviderSet = new Set(popularProviders)
 
-export const isVisibleProvider = (provider: { id: string; source?: string }) =>
-  popularProviderSet.has(provider.id) || provider.id === "deepagent" || provider.source === "custom"
-
 export function useProviders() {
   const serverSync = useServerSync()
   const params = useParams()
@@ -41,19 +38,13 @@ export function useProviders() {
       return pipe(
         providers().all,
         Iterable.map(([, p]) => p),
-        Iterable.filter((p) => connected.has(p.id) && isVisibleProvider(p)),
+        Iterable.filter((p) => connected.has(p.id)),
         (v) => Array.from(v),
       )
     },
     paid: () => {
       const connected = new Set(providers().connected)
-      return [
-        ...Iterable.filter(
-          providers().all,
-          ([id, provider]) =>
-            connected.has(id) && isVisibleProvider(provider),
-        ),
-      ]
+      return [...Iterable.filter(providers().all, ([id]) => connected.has(id))]
     },
   }
 }

--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -54,7 +54,7 @@ export const Model = Schema.Struct({
     Schema.Union([
       Schema.Literal(true),
       Schema.Struct({
-        field: Schema.Literals(["reasoning_content", "reasoning_details"]),
+        field: Schema.Literals(["reasoning", "reasoning_content", "reasoning_details"]),
       }),
     ]),
   ),

--- a/packages/core/src/v1/config/provider.ts
+++ b/packages/core/src/v1/config/provider.ts
@@ -18,7 +18,7 @@ export const Model = Schema.Struct({
     Schema.Union([
       Schema.Literal(true),
       Schema.Struct({
-        field: Schema.Literals(["reasoning_content", "reasoning_details"]),
+        field: Schema.Literals(["reasoning", "reasoning_content", "reasoning_details"]),
       }),
     ]),
   ),

--- a/packages/deepagent-code/src/config/config.ts
+++ b/packages/deepagent-code/src/config/config.ts
@@ -187,6 +187,68 @@ function globalConfigFile() {
   return candidates[0]
 }
 
+// Single canonical global config file. We still LOAD the legacy names for backward compatibility
+// (loadGlobal merges all of them), but users should only ever have to edit ONE file. This
+// consolidates any legacy config.json / deepagent-code.json into deepagent-code.jsonc at startup
+// and removes the old files, so plugins and providers no longer end up split across files.
+const CANONICAL_GLOBAL_CONFIG = "deepagent-code.jsonc"
+const LEGACY_GLOBAL_CONFIGS = ["config.json", "deepagent-code.json"]
+
+async function migrateGlobalConfigFiles() {
+  const dir = Global.Path.config
+  const canonicalPath = path.join(dir, CANONICAL_GLOBAL_CONFIG)
+  const legacyPaths = LEGACY_GLOBAL_CONFIGS.map((name) => path.join(dir, name)).filter((file) => existsSync(file))
+  if (legacyPaths.length === 0) return
+
+  // Parse strictly: if ANY legacy or canonical file is broken (bad JSON OR invalid schema), skip
+  // migration entirely so the normal load path still surfaces the error via getErrors() against the
+  // original file. We must not silently move/drop content from a file the user needs to be told is
+  // broken — moving it would also relabel the error against the wrong (canonical) filename.
+  const parseStrict = (raw: string): Record<string, unknown> | undefined => {
+    try {
+      const value = ConfigParse.jsonc(raw, "migrate")
+      if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+      // Schema-validate too: an invalid-field file must keep surfacing its schema error in place.
+      ConfigParse.schema(ConfigV1.Info, value, "migrate")
+      return value as Record<string, unknown>
+    } catch {
+      return undefined
+    }
+  }
+
+  // Load order = config.json -> deepagent-code.json -> deepagent-code.jsonc, so the canonical
+  // .jsonc wins over legacy. Build the merged object in that precedence.
+  let merged: Record<string, unknown> = {}
+  for (const file of legacyPaths) {
+    const parsed = parseStrict(await fsNode.readFile(file, "utf8").catch(() => ""))
+    if (!parsed) return // broken legacy file — leave everything in place for error reporting
+    merged = { ...merged, ...parsed }
+  }
+
+  let canonicalExisting: Record<string, unknown> | undefined
+  if (existsSync(canonicalPath)) {
+    canonicalExisting = parseStrict(await fsNode.readFile(canonicalPath, "utf8").catch(() => ""))
+    if (!canonicalExisting) return // broken canonical file — don't touch anything
+  }
+
+  if (canonicalExisting) {
+    // Preserve the user's existing .jsonc (and its comments): patch in only the legacy keys that
+    // aren't already set in the canonical file.
+    let text = await fsNode.readFile(canonicalPath, "utf8").catch(() => "{}")
+    for (const [key, value] of Object.entries(merged)) {
+      if (key in canonicalExisting) continue
+      text = patchJsonc(text, { [key]: value })
+    }
+    await fsNode.writeFile(canonicalPath, text)
+  } else {
+    merged.$schema ??= "https://deepagent-code.ai/config.json"
+    await fsNode.mkdir(dir, { recursive: true }).catch(() => {})
+    await fsNode.writeFile(canonicalPath, JSON.stringify(merged, null, 2))
+  }
+
+  for (const file of legacyPaths) await fsNode.unlink(file).catch(() => {})
+}
+
 function patchJsonc(input: string, patch: unknown, path: string[] = []): string {
   if (!isRecord(patch)) {
     const edits = modify(input, path, patch, {
@@ -294,6 +356,10 @@ export const layer = Layer.effect(
       // Seed the default global config with the schema for editor completion, but avoid writing when the user
       // explicitly routes config through env-provided paths or content.
       if (!Flag.DEEPAGENT_CODE_CONFIG && !Flag.DEEPAGENT_CODE_CONFIG_DIR && !Flag.DEEPAGENT_CODE_CONFIG_CONTENT) {
+        // Consolidate any legacy config.json / deepagent-code.json into the single canonical
+        // deepagent-code.jsonc and remove the old files, so there is one config file to edit.
+        // Best-effort: a failure here must not block config loading (we still merge all names below).
+        yield* Effect.promise(() => migrateGlobalConfigFiles()).pipe(Effect.catch(() => Effect.void))
         const file = globalConfigFile()
         if (!existsSync(file)) {
           yield* fs

--- a/packages/deepagent-code/src/provider/provider.ts
+++ b/packages/deepagent-code/src/provider/provider.ts
@@ -44,7 +44,6 @@ import {
 
 const log = Log.create({ service: "provider" })
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 10_000
-const PRODUCT_PROVIDER_IDS = new Set(["openai", "deepseek", "anthropic", "deepagent", "deepagent-code"])
 
 function providerEnvKey(configuredEnv: string[], envs: Record<string, string | undefined>) {
   const configured = configuredEnv.find((item) => envs[item])
@@ -937,7 +936,7 @@ const ProviderModalities = Schema.Struct({
 const ProviderInterleaved = Schema.Union([
   Schema.Boolean,
   Schema.Struct({
-    field: Schema.Literals(["reasoning_content", "reasoning_details"]),
+    field: Schema.Literals(["reasoning", "reasoning_content", "reasoning_details"]),
   }),
 ])
 
@@ -1324,33 +1323,12 @@ export const layer = Layer.effect(
         const configProviders = Object.entries(cfg.provider ?? {})
         const disabled = new Set(cfg.disabled_providers ?? [])
         const enabled = cfg.enabled_providers ? new Set(cfg.enabled_providers) : null
-        const configuredProviderIDs = new Set(configProviders.map(([id]) => id))
         const envs = yield* env.all()
         const allAuths = yield* auth.all().pipe(Effect.orDie)
-        const authProviderIDs = new Set(Object.keys(allAuths))
-        const envProviderIDs = new Set(
-          Object.entries(database)
-            .filter(([, provider]) => providerEnvKey(provider.env, envs) !== undefined)
-            .map(([id]) => id),
-        )
-
-        function isProductProvider(providerID: string): boolean {
-          return PRODUCT_PROVIDER_IDS.has(providerID)
-        }
-
-        function isExplicitCompatibilityProvider(providerID: string): boolean {
-          if (isProductProvider(providerID)) return true
-          if (enabled?.has(providerID)) return true
-          if (configuredProviderIDs.has(providerID)) return true
-          if (authProviderIDs.has(providerID)) return true
-          if (envProviderIDs.has(providerID)) return true
-          return false
-        }
 
         function isProviderAllowed(providerID: ProviderV2.ID): boolean {
           if (enabled && !enabled.has(providerID)) return false
           if (disabled.has(providerID)) return false
-          if (!isExplicitCompatibilityProvider(providerID)) return false
           return true
         }
 
@@ -1583,6 +1561,25 @@ export const layer = Layer.effect(
 
           for (const [modelID, model] of Object.entries(provider.models)) {
             model.api.id = model.api.id ?? model.id ?? modelID
+            // Registration-time boundary for the hosted "deepagent" gateway provider only. Third-party
+            // providers are unrestricted (parity with upstream opencode). We validate once here at load
+            // time instead of throwing per-request in resolveSDK/transform: the hosted gateway only
+            // routes to a vetted set of upstream providers/packages, so an out-of-policy model is dropped
+            // from the catalog rather than failing mid-request.
+            if (providerID === "deepagent") {
+              const upstreamProviderID = deepagentUpstreamProviderID(model)
+              const packageAllowed =
+                model.api.npm.startsWith("file://") || SUPPORTED_DEEPAGENT_PROVIDER_PACKAGES.has(model.api.npm)
+              if (!SUPPORTED_DEEPAGENT_PROVIDER_IDS.has(upstreamProviderID) || !packageAllowed) {
+                log.warn("dropping unsupported deepagent upstream model", {
+                  modelID,
+                  upstreamProviderID,
+                  npm: model.api.npm,
+                })
+                delete provider.models[modelID]
+                continue
+              }
+            }
             if (
               // These chat aliases are invalid for the special handling in the
               // built-in providers below, but custom providers may support them.
@@ -1636,18 +1633,6 @@ export const layer = Layer.effect(
 
     const list = Effect.fn("Provider.list")(() => InstanceState.use(state, (s) => s.providers))
 
-    function assertDeepAgentRuntimeBoundary(model: Model) {
-      if (model.providerID !== "deepagent") return
-      const upstreamProviderID = deepagentUpstreamProviderID(model)
-      if (!SUPPORTED_DEEPAGENT_PROVIDER_IDS.has(upstreamProviderID)) {
-        throw new Error(`Unsupported DeepAgent upstream provider: ${upstreamProviderID}`)
-      }
-      if (model.api.npm.startsWith("file://")) return
-      if (!SUPPORTED_DEEPAGENT_PROVIDER_PACKAGES.has(model.api.npm)) {
-        throw new Error(`Unsupported DeepAgent upstream provider package: ${model.api.npm}`)
-      }
-    }
-
     function deepagentModelAuthProviderID(model: Model) {
       if (model.providerID !== "deepagent") return
       const value = model.options?.authProviderID
@@ -1662,7 +1647,6 @@ export const layer = Layer.effect(
       modelAuth?: Auth.Info,
     ) {
       try {
-        assertDeepAgentRuntimeBoundary(model)
         using _ = log.time("getSDK", {
           providerID: model.providerID,
         })

--- a/packages/deepagent-code/src/provider/transform.ts
+++ b/packages/deepagent-code/src/provider/transform.ts
@@ -3,7 +3,7 @@ import { mergeDeep, unique } from "remeda"
 import type { JSONSchema7 } from "@ai-sdk/provider"
 import type * as Provider from "./provider"
 import type * as ModelsDev from "@deepagent-code/core/models-dev"
-import { SUPPORTED_DEEPAGENT_PROVIDER_IDS, deepagentUpstreamProviderID } from "./compatibility"
+import { deepagentUpstreamProviderID } from "./compatibility"
 import { iife } from "@/util/iife"
 
 type Modality = NonNullable<ModelsDev.Model["modalities"]>["input"][number]
@@ -22,11 +22,6 @@ export const OUTPUT_TOKEN_MAX = 32_000
 // needed for stateless multi-turn reasoning (store: false). Hoisted so every
 // branch that requests it stays in lockstep.
 const INCLUDE_ENCRYPTED_REASONING = ["reasoning.encrypted_content"] as const
-const MAIN_TRANSFORM_PACKAGES = new Set(["@ai-sdk/openai", "@ai-sdk/openai-compatible", "@ai-sdk/anthropic"])
-
-function mainTransformProvider(model: Provider.Model) {
-  return model.providerID === "deepagent" ? model.api.npm.startsWith("file://") : true
-}
 
 export function sanitizeSurrogates(content: string) {
   return content.replace(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g, "\uFFFD")
@@ -645,7 +640,6 @@ function googleThinkingVariants(model: Provider.Model): Record<string, Record<st
 
 export function variants(model: Provider.Model): Record<string, Record<string, any>> {
   if (!model.capabilities.reasoning) return {}
-  if (!mainTransformProvider(model)) return {}
 
   const id = model.id.toLowerCase()
   const adaptiveOpus = anthropicOpus47OrLater(model.api.id)
@@ -1023,15 +1017,6 @@ export function options(input: {
     input.model.providerID === "deepagent"
       ? deepagentUpstreamProviderID(input.model)
       : input.model.providerID
-
-  if (input.model.providerID === "deepagent") {
-    if (!SUPPORTED_DEEPAGENT_PROVIDER_IDS.has(upstreamProviderID)) {
-      throw new Error(`Unsupported DeepAgent upstream provider: ${upstreamProviderID}`)
-    }
-    if (!input.model.api.npm.startsWith("file://") && !MAIN_TRANSFORM_PACKAGES.has(input.model.api.npm)) {
-      throw new Error(`Unsupported DeepAgent upstream provider package: ${input.model.api.npm}`)
-    }
-  }
 
   if (
     input.model.api.npm === "@ai-sdk/google-vertex/anthropic" ||

--- a/packages/deepagent-code/src/server/routes/instance/httpapi/handlers/provider.ts
+++ b/packages/deepagent-code/src/server/routes/instance/httpapi/handlers/provider.ts
@@ -13,16 +13,6 @@ import { InstanceHttpApi } from "../api"
 import { ProviderAuthApiError, ProviderModelDiscoverError } from "../groups/provider"
 import { ProviderV2 } from "@deepagent-code/core/provider"
 
-const builtinProviderIDs = new Set(["openai", "deepseek", "anthropic"])
-
-function allowedProviderIDs(config: { provider?: Record<string, unknown> }, catalog: Record<string, unknown>) {
-  const ids = new Set(builtinProviderIDs)
-  for (const id of Object.keys(config.provider ?? {})) {
-    if (!builtinProviderIDs.has(id) && catalog[id] === undefined) ids.add(id)
-  }
-  return ids
-}
-
 function mapProviderAuthError<A, R>(self: Effect.Effect<A, ProviderAuth.Error, R>) {
   return self.pipe(
     Effect.mapError((error) => {
@@ -55,22 +45,20 @@ export const providerHandlers = HttpApiBuilder.group(InstanceHttpApi, "provider"
       const all = yield* ModelsDev.Service.use((s) => s.get())
       const disabled = new Set(config.disabled_providers ?? [])
       const enabled = config.enabled_providers ? new Set(config.enabled_providers) : undefined
-      const allowed = allowedProviderIDs(config, all)
       const filtered: Record<string, (typeof all)[string]> = {}
       for (const [key, value] of Object.entries(all)) {
-        if (allowed.has(key) && (enabled ? enabled.has(key) : true) && !disabled.has(key)) filtered[key] = value
+        if ((enabled ? enabled.has(key) : true) && !disabled.has(key)) filtered[key] = value
       }
       const connected = yield* provider.list()
-      const filteredConnected = Object.fromEntries(Object.entries(connected).filter(([key]) => allowed.has(key)))
       const providers = Object.assign(
         mapValues(filtered, (item) => Provider.fromModelsDevProvider(item)),
-        filteredConnected,
+        connected,
       )
       const errors = yield* cfg.getErrors()
       return {
         all: Object.values(providers).map(Provider.toPublicInfo),
         default: Provider.defaultModelIDs(providers),
-        connected: Object.keys(filteredConnected),
+        connected: Object.keys(connected),
         errors: errors.length ? errors : undefined,
       }
     })

--- a/packages/deepagent-code/test/config/config.test.ts
+++ b/packages/deepagent-code/test/config/config.test.ts
@@ -29,6 +29,7 @@ import { CrossSpawnSpawner } from "@deepagent-code/core/cross-spawn-spawner"
 import { testEffect } from "../lib/effect"
 import path from "path"
 import fs from "fs/promises"
+import { existsSync } from "fs"
 import os from "os"
 import { pathToFileURL } from "url"
 import { Global } from "@deepagent-code/core/global"
@@ -668,6 +669,98 @@ it.effect("captures invalid fields in a global config file as a schema error", (
           const schemaError = errors.find((e) => e.source.endsWith("config.json"))
           expect(schemaError?.kind).toBe("schema")
           expect(schemaError?.message).toContain("not_a_real_field")
+        }),
+      ),
+    )
+  }),
+)
+
+it.effect("consolidates legacy global config files into deepagent-code.jsonc and removes them", () =>
+  Effect.gen(function* () {
+    const globalDir = yield* tmpdirScoped()
+    const projectDir = yield* tmpdirScoped()
+    // Plugins in one legacy file, model in another — the exact split that confused users.
+    yield* FSUtil.use.writeWithDirs(
+      path.join(globalDir, "config.json"),
+      JSON.stringify({ $schema: "https://deepagent-code.ai/config.json", model: "kept/model" }),
+    )
+    yield* FSUtil.use.writeWithDirs(
+      path.join(globalDir, "deepagent-code.json"),
+      JSON.stringify({ plugin: ["my-plugin"] }),
+    )
+
+    yield* withGlobalConfigDir(
+      globalDir,
+      withInstanceDir(
+        projectDir,
+        Effect.gen(function* () {
+          const config = yield* Config.use.get()
+          // Both settings survive the merge.
+          expect(config.model).toBe("kept/model")
+          expect(config.plugin).toContain("my-plugin")
+
+          // Legacy files are gone; the single canonical file remains.
+          expect(existsSync(path.join(globalDir, "config.json"))).toBe(false)
+          expect(existsSync(path.join(globalDir, "deepagent-code.json"))).toBe(false)
+          expect(existsSync(path.join(globalDir, "deepagent-code.jsonc"))).toBe(true)
+        }),
+      ),
+    )
+  }),
+)
+
+it.effect("merges legacy keys into an existing .jsonc while preserving its comments", () =>
+  Effect.gen(function* () {
+    const globalDir = yield* tmpdirScoped()
+    const projectDir = yield* tmpdirScoped()
+    yield* FSUtil.use.writeWithDirs(
+      path.join(globalDir, "deepagent-code.jsonc"),
+      '{\n  // my providers\n  "model": "canonical/wins"\n}',
+    )
+    yield* FSUtil.use.writeWithDirs(
+      path.join(globalDir, "deepagent-code.json"),
+      JSON.stringify({ model: "legacy/loses", plugin: ["legacy-plugin"] }),
+    )
+
+    yield* withGlobalConfigDir(
+      globalDir,
+      withInstanceDir(
+        projectDir,
+        Effect.gen(function* () {
+          const config = yield* Config.use.get()
+          // Canonical value wins; legacy-only key is merged in.
+          expect(config.model).toBe("canonical/wins")
+          expect(config.plugin).toContain("legacy-plugin")
+
+          const text = yield* FSUtil.use.readFileString(path.join(globalDir, "deepagent-code.jsonc"))
+          expect(text).toContain("// my providers")
+          expect(existsSync(path.join(globalDir, "deepagent-code.json"))).toBe(false)
+        }),
+      ),
+    )
+  }),
+)
+
+it.effect("does not migrate (or delete) legacy files when one is broken", () =>
+  Effect.gen(function* () {
+    const globalDir = yield* tmpdirScoped()
+    const projectDir = yield* tmpdirScoped()
+    yield* FSUtil.use.writeWithDirs(
+      path.join(globalDir, "config.json"),
+      JSON.stringify({ $schema: "https://deepagent-code.ai/config.json", model: "kept/model" }),
+    )
+    yield* FSUtil.use.writeWithDirs(path.join(globalDir, "deepagent-code.json"), "{ not valid json }")
+
+    yield* withGlobalConfigDir(
+      globalDir,
+      withInstanceDir(
+        projectDir,
+        Effect.gen(function* () {
+          yield* Config.use.get()
+          // Broken legacy file present -> migration bails; both legacy files stay put so the broken
+          // one keeps surfacing its error in place.
+          expect(existsSync(path.join(globalDir, "config.json"))).toBe(true)
+          expect(existsSync(path.join(globalDir, "deepagent-code.json"))).toBe(true)
         }),
       ),
     )

--- a/packages/deepagent-code/test/deepagent/provider-scope.test.ts
+++ b/packages/deepagent-code/test/deepagent/provider-scope.test.ts
@@ -14,15 +14,22 @@ describe("DeepAgent global runtime scope", () => {
     expect(source).not.toContain("ONE" + "AGENT")
   })
 
-  test("DeepAgent provider runtime is fenced to supported upstream providers", async () => {
+  test("DeepAgent hosted provider is fenced at registration time, third-party providers are unrestricted", async () => {
     const providerSource = await readFile("src/provider/provider.ts", "utf8")
     const transformSource = await readFile("src/provider/transform.ts", "utf8")
 
+    // The hosted "deepagent" gateway still self-restricts to vetted upstream providers/packages,
+    // but this is now enforced once at catalog-load time (out-of-policy models are dropped) rather
+    // than thrown per-request. The whitelist constant and the registration-time guard remain.
     expect(providerSource).toContain("SUPPORTED_DEEPAGENT_PROVIDER_PACKAGES")
     expect(providerSource).toContain("COMPATIBILITY_PROVIDER_LOADERS")
-    expect(providerSource).toContain("Unsupported DeepAgent upstream provider")
-    expect(transformSource).toContain("Unsupported DeepAgent upstream provider")
+    expect(providerSource).toContain('providerID === "deepagent"')
+    expect(providerSource).toContain("dropping unsupported deepagent upstream model")
+
+    // Parity with upstream opencode: third-party providers are NOT gated. The per-request throws that
+    // previously rejected non-whitelisted upstreams/packages have been removed from both files.
+    expect(providerSource).not.toContain("Unsupported DeepAgent upstream provider")
+    expect(transformSource).not.toContain("Unsupported DeepAgent upstream provider")
     expect(transformSource).toContain('"@ai-sdk/openai-compatible"')
-    expect(transformSource).not.toContain('input.model.providerID === "deepagent" && input.model.api.npm === "@ai-sdk/google"')
   })
 })

--- a/packages/sdk/js/src/gen/types.gen.ts
+++ b/packages/sdk/js/src/gen/types.gen.ts
@@ -1817,7 +1817,7 @@ export type ProviderConfig = {
       interleaved?:
         | true
         | {
-            field: "reasoning_content" | "reasoning_details"
+            field: "reasoning" | "reasoning_content" | "reasoning_details"
           }
       cost?: {
         input: number
@@ -2097,7 +2097,7 @@ export type Model = {
     interleaved:
       | boolean
       | {
-          field: "reasoning_content" | "reasoning_details"
+          field: "reasoning" | "reasoning_content" | "reasoning_details"
         }
   }
   cost: {

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1817,7 +1817,7 @@ export type ProviderConfig = {
       interleaved?:
         | true
         | {
-            field: "reasoning_content" | "reasoning_details"
+            field: "reasoning" | "reasoning_content" | "reasoning_details"
           }
       cost?: {
         input: number
@@ -2097,7 +2097,7 @@ export type Model = {
     interleaved:
       | boolean
       | {
-          field: "reasoning_content" | "reasoning_details"
+          field: "reasoning" | "reasoning_content" | "reasoning_details"
         }
   }
   cost: {

--- a/packages/ui/src/components/basic-tool.tsx
+++ b/packages/ui/src/components/basic-tool.tsx
@@ -88,6 +88,10 @@ export function BasicTool(props: BasicToolProps) {
   const open = () => props.open ?? state.open
   const ready = () => state.ready
   const pending = () => props.status === "pending" || props.status === "running"
+  // A tool that has not produced anything yet (queued, not executing) stays non-interactive.
+  // Once it is "running" it streams partial output, so the user must be able to expand it to
+  // watch progress instead of waiting for completion.
+  const notStarted = () => props.status === "pending"
   const hasChildren = () => (props.defer ? "children" in props : props.children)
 
   let cancelReady: (() => void) | undefined
@@ -173,7 +177,7 @@ export function BasicTool(props: BasicToolProps) {
   })
 
   const handleOpenChange = (value: boolean) => {
-    if (pending()) return
+    if (notStarted()) return
     if (props.locked && !value) return
     setOpen(value)
   }
@@ -243,7 +247,7 @@ export function BasicTool(props: BasicToolProps) {
           </Switch>
         </div>
       </div>
-      <Show when={hasChildren() && !props.hideDetails && !props.locked && !pending()}>
+      <Show when={hasChildren() && !props.hideDetails && !props.locked && !notStarted()}>
         <Collapsible.Arrow />
       </Show>
     </div>


### PR DESCRIPTION
## Summary

恢复第三方 provider 接入(对齐上游 opencode),并修复几个内测反馈问题。

### 1. 第三方 provider parity (90560f514)
第三方/自定义 provider 与 deepagent 官方 API 同权,移除"只允许官方 API"时加的门控:
- server: 删 builtinProviderIDs/allowedProviderIDs 过滤,connected 全量返回
- provider: 删 isProviderAllowed 的 isExplicitCompatibilityProvider 门
- transform/provider: deepagent 白名单改为加载期生效(超策略模型从 catalog 丢弃),不再 per-request throw;第三方不受限
- config schema: interleaved.field 补回 reasoning 枚举(core v1 + models-dev + sdk types)
- app: 删 model/provider 选择器的 isVisibleProvider/popularProviders 过滤

### 2. 许愿模式回退修复 (88cc47400)
resetScenarioOnStop 之前把持久 direct 写进 override map,退出许愿后回不去。改为 stop 时清除 override,下一轮回落配置默认(许愿)。

### 3. shell 运行中可展开 (aa6611596)
工具卡片 running 时禁止展开,用户以为卡死。改为仅未启动(pending)不可交互,running 可展开看流式输出。

### 4. 全局配置统一 (b10f26323)
启动迁移把 legacy config.json/deepagent-code.json 合并进唯一 deepagent-code.jsonc 并删除旧文件。已有 .jsonc 保留注释、canonical 优先;任一文件非法则跳过迁移留原地报错。

## Test
- llm executor 16 pass / ui 27 pass / config 97 pass(含3新增迁移测试)/ provider-scope 2 pass
- 受影响包 typecheck 全过(pre-push 23 包)

🤖 Generated with [Claude Code](https://claude.com/claude-code)