### PR TITLE
feat(ci): publish desktop builds to releases (#11)

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,7 +1,7 @@
 name: desktop-build
 
-# Internal-beta packaging: builds the desktop app for download as workflow artifacts.
-# Does NOT publish, version-bump, or create releases.
+# Desktop packaging: builds installable packages and publishes the latest main
+# build as an auto-managed GitHub Release.
 #
 # macOS signing/notarization is opt-in: if the APPLE_* / CSC_* secrets are present it
 # signs, otherwise it builds an UNSIGNED package (testers right-click → Open to launch).
@@ -33,7 +33,7 @@ on:
           - windows
 
 permissions:
-  contents: read
+  contents: write
   actions: write
 
 concurrency:
@@ -157,3 +157,46 @@ jobs:
             packages/desktop/dist/*.dmg
             packages/desktop/dist/*.deb
             packages/desktop/dist/*.exe
+
+  release:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: deepagent-code-desktop-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Publish latest desktop release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          version=$(node -p 'require("./packages/desktop/package.json").version.replace(/-.*/, "")')
+          tag="app-v${version}-main.${GITHUB_RUN_NUMBER}"
+
+          mapfile -t assets < <(find release-assets -type f \( -name '*.dmg' -o -name '*.deb' -o -name '*.exe' \) | sort)
+          if [ "${#assets[@]}" -eq 0 ]; then
+            echo "No desktop release assets found"
+            exit 1
+          fi
+
+          gh release list --repo "$REPOSITORY" --limit 100 --json tagName \
+            --jq '.[] | select(.tagName | test("^app-v[0-9]+\\.[0-9]+\\.[0-9]+-main\\.")) | .tagName' \
+            | while read -r old_tag; do
+                if [ -n "$old_tag" ]; then
+                  gh release delete "$old_tag" --repo "$REPOSITORY" --cleanup-tag -y
+                fi
+              done
+
+          gh release create "$tag" "${assets[@]}" \
+            --repo "$REPOSITORY" \
+            --latest \
+            --title "DeepAgent Code Desktop ${version} (${GITHUB_SHA::7})" \
+            --notes "Automated desktop build from main at ${GITHUB_SHA}."


### PR DESCRIPTION
### Issue for this PR

N/A - release automation follow-up.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Publishes successful desktop package artifacts from main builds into an auto-managed GitHub Release. Older automatic desktop releases matching `app-v*-main.*` are deleted before creating the new release so release storage stays bounded.

### How did you verify your code works?

- Ran `actionlint .github/workflows/desktop-build.yml`
- Push hook ran `bun turbo typecheck` successfully: 23/23 tasks

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
