### PR TITLE
feat(ci): target desktop releases to build commit

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -198,5 +198,6 @@ jobs:
           gh release create "$tag" "${assets[@]}" \
             --repo "$REPOSITORY" \
             --latest \
+            --target "$GITHUB_SHA" \
             --title "DeepAgent Code Desktop ${version} (${GITHUB_SHA::7})" \
             --notes "Automated desktop build from main at ${GITHUB_SHA}."


### PR DESCRIPTION
### Issue for this PR

N/A - release automation correction.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Targets automatic desktop Release tags at the main build commit SHA instead of the repository default branch. This keeps `app-v*-main.*` releases tied to the exact commit that produced the packages.

### How did you verify your code works?

- Ran `actionlint .github/workflows/desktop-build.yml`
- Push hook ran `bun turbo typecheck` successfully: 23/23 tasks

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
