### PR TITLE
add effect-smol submodule for effect skill integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".repos/effect-smol"]
+	path = .repos/effect-smol
+	url = https://github.com/Effect-TS/effect-smol.git


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Effect skill requires `effect-smol` (i.e. Effect v4) repo to be at `.repo/` so that agents can lookup for official Effect codes for references.