### PR TITLE
fix(nix): update node_modules hash and use build-time bun version for version check

### DIFF
--- a/nix/deepagent-code.nix
+++ b/nix/deepagent-code.nix
@@ -18,6 +18,11 @@ stdenvNoCC.mkDerivation (finalAttrs: {
   inherit (node_modules) version src;
   inherit node_modules;
 
+  patchPhase = ''
+    BUN_VERSION=$(bun --version)
+    sed -i "s/const expectedBunVersionRange.*/const expectedBunVersionRange = \"^$BUN_VERSION\";/" packages/script/src/index.ts
+  '';
+
   nativeBuildInputs = [
     bun
     nodejs # for patchShebangs node_modules

--- a/nix/hashes.json
+++ b/nix/hashes.json
@@ -1,6 +1,6 @@
 {
   "nodeModules": {
-    "x86_64-linux": "sha256-OttgLsPJSYW1b9RGqiYSi7qPdDC3GuD2FE7k5tPe6Iw=",
+    "x86_64-linux": "sha256-vB4imi5LtCxnDuOaJFQh+asK51RUDCnIVCkIzBQN12o=",
     "aarch64-linux": "sha256-VsmW8tTiT3VkTxp5oiYc/maJLSsBMxK6VVUSVshWVT8=",
     "aarch64-darwin": "sha256-/MaQBX2zoJMtLA8jHt8+uKpIFve/eec3RfcKT3FvXC8=",
     "x86_64-darwin": "sha256-3ggap9rgR2TvVbYgnXsgkg6Rj1TqNZu32QgTVRdN0f0="


### PR DESCRIPTION
## Changes

1. **nix/hashes.json**: Update `x86_64-linux` node_modules hash to match current nixpkgs-unstable snapshot
2. **nix/deepagent-code.nix**: Add `patchPhase` that dynamically reads the actual bun version at build time, instead of hardcoding `^1.3.14`. This avoids build failures when nixpkgs-unstable ships a slightly different bun version (e.g., 1.3.13).

## Related

Closes #27