### PR TITLE
fix(session): turn-token footer shows spend, not cached context

### DIFF
--- a/packages/app/src/components/session/session-context-metrics.test.ts
+++ b/packages/app/src/components/session/session-context-metrics.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import type { Message, Session } from "@deepagent-code/sdk/v2/client"
-import { getConversationTokens, getSessionContextMetrics, getSubagentTokens } from "./session-context-metrics"
+import {
+  getConversationTokens,
+  getSessionContextMetrics,
+  getSubagentTokens,
+  getSubagentTokenBreakdown,
+  addTokenBreakdown,
+  emptyTokenBreakdown,
+} from "./session-context-metrics"
 
 const assistant = (
   id: string,
@@ -125,6 +132,52 @@ describe("getSubagentTokens", () => {
 
   test("undefined session -> 0", () => {
     expect(getSubagentTokens(undefined)).toBe(0)
+  })
+})
+
+describe("token breakdown", () => {
+  test("spend excludes cache read/write; total includes everything", () => {
+    // Mirrors the reported case: a short prompt over a large cached context. spend is small even
+    // though total is dominated by the re-read cache.
+    const acc = addTokenBreakdown(emptyTokenBreakdown(), {
+      input: 800,
+      output: 400,
+      reasoning: 100,
+      cache: { read: 119_000, write: 367 },
+    })
+    expect(acc.spend).toBe(1300) // 800 + 400 + 100 — no cache
+    expect(acc.total).toBe(120_667) // + 119_000 read + 367 write
+    expect(acc.cacheRead).toBe(119_000)
+    expect(acc.cacheWrite).toBe(367)
+  })
+
+  test("addTokenBreakdown accumulates across multiple messages", () => {
+    const acc = emptyTokenBreakdown()
+    addTokenBreakdown(acc, { input: 10, output: 5, reasoning: 2, cache: { read: 3, write: 1 } })
+    addTokenBreakdown(acc, { input: 20, output: 10, reasoning: 0, cache: { read: 6, write: 0 } })
+    expect(acc.input).toBe(30)
+    expect(acc.output).toBe(15)
+    expect(acc.reasoning).toBe(2)
+    expect(acc.cacheRead).toBe(9)
+    expect(acc.cacheWrite).toBe(1)
+    expect(acc.spend).toBe(47) // (10+5+2) + (20+10+0)
+    expect(acc.total).toBe(57) // spend + 9 read + 1 write
+  })
+
+  test("getSubagentTokenBreakdown rolls a child session into the accumulator", () => {
+    const acc = emptyTokenBreakdown()
+    const s = session("s1", undefined, { input: 100, output: 40, reasoning: 10, read: 5, write: 5 })
+    getSubagentTokenBreakdown(acc, s)
+    expect(acc.spend).toBe(150) // 100 + 40 + 10
+    expect(acc.total).toBe(160) // + 5 + 5 — matches getSubagentTokens
+    expect(acc.total).toBe(getSubagentTokens(s))
+  })
+
+  test("getSubagentTokenBreakdown with undefined session is a no-op", () => {
+    const acc = emptyTokenBreakdown()
+    getSubagentTokenBreakdown(acc, undefined)
+    expect(acc.total).toBe(0)
+    expect(acc.spend).toBe(0)
   })
 })
 

--- a/packages/app/src/components/session/session-context-metrics.ts
+++ b/packages/app/src/components/session/session-context-metrics.ts
@@ -128,3 +128,49 @@ export function getConversationTokens(sessions: Session[] = [], rootSessionID?: 
 export function getSubagentTokens(session: Session | undefined): number {
   return session ? sessionTokensUsed(session) : 0
 }
+
+// Per-category token breakdown. `spend` is the tokens NEWLY consumed this turn (non-cached input +
+// output + reasoning); `cacheRead`/`cacheWrite` are the cached context re-read/written for the same
+// request (billed at a fraction of full price). `total` is the sum of all five — the raw figure the
+// provider reports. Surfacing the split stops a short prompt over a large cached context from looking
+// like it "spent" 120K when almost all of that is a cache hit.
+export type TokenBreakdown = {
+  input: number
+  output: number
+  reasoning: number
+  cacheRead: number
+  cacheWrite: number
+  spend: number
+  total: number
+}
+
+export const emptyTokenBreakdown = (): TokenBreakdown => ({
+  input: 0,
+  output: 0,
+  reasoning: 0,
+  cacheRead: 0,
+  cacheWrite: 0,
+  spend: 0,
+  total: 0,
+})
+
+export function addTokenBreakdown(
+  acc: TokenBreakdown,
+  t: { input: number; output: number; reasoning: number; cache: { read: number; write: number } },
+): TokenBreakdown {
+  acc.input += t.input
+  acc.output += t.output
+  acc.reasoning += t.reasoning
+  acc.cacheRead += t.cache.read
+  acc.cacheWrite += t.cache.write
+  acc.spend += t.input + t.output + t.reasoning
+  acc.total += t.input + t.output + t.reasoning + t.cache.read + t.cache.write
+  return acc
+}
+
+// Breakdown of a single subagent (child) session's persisted running total, mirroring
+// {@link getSubagentTokens} but split by category so it can roll into a parent turn's tooltip.
+export function getSubagentTokenBreakdown(acc: TokenBreakdown, session: Session | undefined): TokenBreakdown {
+  if (!session?.tokens) return acc
+  return addTokenBreakdown(acc, session.tokens)
+}

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -534,6 +534,14 @@ export const dict = {
   "context.usage.totalTokens": "Conversation Tokens",
   "context.usage.clickToView": "Click to view context",
   "context.usage.view": "View context usage",
+  "context.usage.input": "Input",
+  "context.usage.output": "Output",
+  "context.usage.reasoning": "Reasoning",
+  "context.usage.cacheRead": "Cache read",
+  "context.usage.cacheWrite": "Cache write",
+
+  "session.turn.tokens.spend": "Spent this turn",
+  "session.turn.tokens.total": "Total (incl. cache)",
 
   "language.en": "English",
   "language.zh": "简体中文",
@@ -595,6 +603,7 @@ export const dict = {
   "toast.project.rootRefused.title": "Can't open the filesystem root",
   "toast.project.rootRefused.description":
     "This conversation points at the filesystem root (\"/\"), which can't be opened for safety. It's likely leftover data — remove or re-target it.",
+  "toast.project.rootRecoveryFailed.title": "Couldn't recover this folder-less conversation",
 
   "toast.update.title": "Update available",
   "toast.update.description": "A new version of DeepAgent Code ({{version}}) is now available to install.",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -483,6 +483,14 @@ export const dict = {
   "context.usage.totalTokens": "对话总 token",
   "context.usage.clickToView": "点击查看上下文",
   "context.usage.view": "查看上下文用量",
+  "context.usage.input": "输入",
+  "context.usage.output": "输出",
+  "context.usage.reasoning": "推理",
+  "context.usage.cacheRead": "缓存读取",
+  "context.usage.cacheWrite": "缓存写入",
+
+  "session.turn.tokens.spend": "本轮消耗",
+  "session.turn.tokens.total": "总计（含缓存）",
 
   "language.en": "English",
   "language.zh": "简体中文",
@@ -1071,6 +1079,7 @@ export const dict = {
   "toast.project.reloadFailed.title": "无法重新加载 {{project}}",
   "toast.project.rootRefused.title": "无法打开文件系统根目录",
   "toast.project.rootRefused.description": "该对话指向文件系统根目录（“/”），出于安全考虑无法打开。这多半是遗留数据，请删除或改指到具体目录。",
+  "toast.project.rootRecoveryFailed.title": "无法恢复该无项目对话",
   "error.server.invalidConfiguration": "配置无效",
   "common.moreCountSuffix": " (还有 {{count}} 个)",
   "common.time.justNow": "刚刚",

--- a/packages/app/src/pages/session/message-timeline.tsx
+++ b/packages/app/src/pages/session/message-timeline.tsx
@@ -56,8 +56,14 @@ import { normalize } from "@deepagent-code/ui/session-diff"
 import { useFileComponent } from "@deepagent-code/ui/context/file"
 import { shouldMarkBoundaryGesture, normalizeWheelDelta } from "@/pages/session/message-gesture"
 import { SessionContextUsage } from "@/components/session-context-usage"
-import { getSubagentTokens } from "@/components/session/session-context-metrics"
+import {
+  getSubagentTokenBreakdown,
+  addTokenBreakdown,
+  emptyTokenBreakdown,
+  type TokenBreakdown,
+} from "@/components/session/session-context-metrics"
 import { useDialog } from "@deepagent-code/ui/context/dialog"
+import { Tooltip } from "@deepagent-code/ui/tooltip"
 import { createResizeObserver } from "@solid-primitives/resize-observer"
 import { useLanguage } from "@/context/language"
 import { useSessionKey } from "@/pages/session/session-layout"
@@ -1041,15 +1047,16 @@ export function MessageTimeline(props: {
     return turnDurationMs(userMessageID)
   }
 
-  // Total tokens USED by a turn (input + output + reasoning + cache), summed across the turn's
-  // assistant messages. Distinct from the top-right retained-context number. Advances as each
-  // tool-loop step finishes (providers report usage per step, not per token).
-  const turnTokens = (userMessageID: string) => {
-    let total = 0
+  // Token usage for a turn, split by category (see TokenBreakdown). The footer surfaces `spend`
+  // (newly-consumed = non-cached input + output + reasoning) as its primary figure, with the full
+  // split — including cache read/write — in a tooltip. This keeps a short prompt over a large cached
+  // context from reading as if it "spent" 120K when nearly all of that is a cache re-read. Advances as
+  // each tool-loop step finishes (providers report usage per step, not per token).
+  const turnTokenBreakdown = (userMessageID: string): TokenBreakdown => {
+    const acc = emptyTokenBreakdown()
     const childIds = new Set<string>()
     for (const message of assistantMessagesByParent().get(userMessageID) ?? emptyAssistantMessages) {
-      const t = message.tokens
-      total += t.input + t.output + t.reasoning + t.cache.read + t.cache.write
+      addTokenBreakdown(acc, message.tokens)
       // Roll in subagent usage: each `task` tool-call in this turn spawns a child session whose
       // persisted total we add. Dedupe by child sessionId so a resumed/multi-call child isn't
       // double-counted.
@@ -1061,8 +1068,8 @@ export function MessageTimeline(props: {
         if (childId) childIds.add(childId)
       }
     }
-    for (const childId of childIds) total += getSubagentTokens(sessionByID().get(childId))
-    return total
+    for (const childId of childIds) getSubagentTokenBreakdown(acc, sessionByID().get(childId))
+    return acc
   }
 
   const assistantCopyPartID = (userMessageID: string) => {
@@ -1301,11 +1308,39 @@ export function MessageTimeline(props: {
           if (typeof ms !== "number") return ""
           return formatDuration(ms, language.t, (n) => n.toLocaleString(language.intl()))
         }
-        const tokens = () => turnTokens(id())
+        const breakdown = () => turnTokenBreakdown(id())
+        // Primary footer figure = tokens newly consumed this turn. The provider's full total (which
+        // includes the re-read cached context) lives in the tooltip so a short prompt over a large
+        // cached window doesn't read as if it "spent" the whole context.
+        const spend = () => breakdown().spend
+        const fmt = (n: number) => n.toLocaleString(language.intl())
+        const tokenTooltip = () => {
+          const b = breakdown()
+          const row = (labelKey: string, value: number) => (
+            <div class="flex items-center justify-between gap-4">
+              <span class="text-text-invert-base">{language.t(labelKey)}</span>
+              <span class="text-text-invert-strong">{fmt(value)}</span>
+            </div>
+          )
+          return (
+            <div class="flex flex-col gap-0.5">
+              {row("session.turn.tokens.spend", b.spend)}
+              {row("context.usage.input", b.input)}
+              {row("context.usage.output", b.output)}
+              <Show when={b.reasoning > 0}>{row("context.usage.reasoning", b.reasoning)}</Show>
+              <Show when={b.cacheRead > 0}>{row("context.usage.cacheRead", b.cacheRead)}</Show>
+              <Show when={b.cacheWrite > 0}>{row("context.usage.cacheWrite", b.cacheWrite)}</Show>
+              <div class="mt-1 pt-1 border-t border-white/15 flex items-center justify-between gap-4">
+                <span class="text-text-invert-base">{language.t("session.turn.tokens.total")}</span>
+                <span class="text-text-invert-strong">{fmt(b.total)}</span>
+              </div>
+            </div>
+          )
+        }
         return (
           <TimelineRowFrame row={turnMetaRow}>
             <div data-slot="session-turn-message-container" class="w-full px-4 md:px-5">
-              <Show when={elapsed() || tokens() > 0}>
+              <Show when={elapsed() || breakdown().total > 0}>
                 <div class="flex items-center gap-1.5 text-12-regular text-text-weak cursor-default pb-1">
                   <Show when={live()}>
                     <Spinner class="size-3.5 shrink-0" style={{ color: tint() ?? "var(--icon-interactive-base)" }} />
@@ -1313,13 +1348,15 @@ export function MessageTimeline(props: {
                   <Show when={elapsed()}>
                     <span>{elapsed()}</span>
                   </Show>
-                  <Show when={tokens() > 0}>
+                  <Show when={breakdown().total > 0}>
                     <Show when={elapsed()}>
                       <span aria-hidden="true">·</span>
                     </Show>
-                    <span>
-                      {tokens().toLocaleString(language.intl())} {language.t("context.usage.tokens")}
-                    </span>
+                    <Tooltip value={tokenTooltip()} placement="top">
+                      <span class="border-b border-dashed border-border-weak-base">
+                        {fmt(spend())} {language.t("context.usage.tokens")}
+                      </span>
+                    </Tooltip>
                   </Show>
                 </div>
               </Show>


### PR DESCRIPTION
The per-turn footer summed input + output + reasoning + cache read + cache write, so a short prompt over a large cached context read as if it "spent" ~120K tokens when nearly all of that was a cache re-read (billed at a fraction of full price).

Show the newly-consumed figure (non-cached input + output + reasoning) as the primary number, with the full per-category split — including cache read/write and the provider's raw total — in a hover tooltip.

- Add TokenBreakdown + addTokenBreakdown/getSubagentTokenBreakdown to session-context-metrics; turnTokens becomes turnTokenBreakdown.
- Footer renders `spend` under a dashed-underline tooltip trigger.
- New i18n keys (en + zh) for the breakdown rows.
- Tests cover the reported 120,667 → spend 1,300 case.

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
