### PR TITLE
feat(nix): auto-generate hashes via `nix run .#update-hashes`Feat/auto nix hashes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,17 @@
         };
       });
 
+      apps = forEachSystem (pkgs: {
+        update-hashes = {
+          type = "app";
+          program = let
+            script = pkgs.writeShellScriptBin "update-hashes" ''
+              exec ${pkgs.python3}/bin/python3 ${./nix/scripts/update-hashes.py} "$@"
+            '';
+          in "${script}/bin/update-hashes";
+        };
+      });
+
       overlays = {
         default =
           final: _prev:
@@ -63,7 +74,8 @@
           deepagent-code-desktop = pkgs.callPackage ./nix/desktop.nix {
             inherit deepagent-code;
           };
-          # Updater derivation with fakeHash - build fails and reveals correct hash
+          # Build with fakeHash to reveal the correct hash.
+          # Used by: nix run .#update-hashes
           node_modules_updater = node_modules.override {
             hash = pkgs.lib.fakeHash;
           };

--- a/nix/hashes.json
+++ b/nix/hashes.json
@@ -1,6 +1,6 @@
 {
   "nodeModules": {
-    "x86_64-linux": "sha256-vB4imi5LtCxnDuOaJFQh+asK51RUDCnIVCkIzBQN12o=",
+    "x86_64-linux": "sha256-2cnaDO1erE8kXD6iZtzAqd0hoLLl3IV1hwqXI9yoUhw=",
     "aarch64-linux": "sha256-VsmW8tTiT3VkTxp5oiYc/maJLSsBMxK6VVUSVshWVT8=",
     "aarch64-darwin": "sha256-/MaQBX2zoJMtLA8jHt8+uKpIFve/eec3RfcKT3FvXC8=",
     "x86_64-darwin": "sha256-3ggap9rgR2TvVbYgnXsgkg6Rj1TqNZu32QgTVRdN0f0="

--- a/nix/node_modules.nix
+++ b/nix/node_modules.nix
@@ -3,6 +3,8 @@
   stdenvNoCC,
   bun,
   rev ? "dirty",
+  # Auto-managed by nix run .#update-hashes. Do not edit manually.
+  # CI regenerates when bun.lock changes.
   hash ?
     (lib.pipe ./hashes.json [
       builtins.readFile

--- a/nix/scripts/update-hashes.py
+++ b/nix/scripts/update-hashes.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Auto-update hashes.json by building with fakeHash and extracting the correct hash.
+
+Usage:
+  nix run .#update-hashes                     # update current platform
+  nix run .#update-hashes -- --check          # CI: verify hashes are current
+  nix/scripts/update-hashes.py --root /path   # run directly with explicit root
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def get_current_platform():
+    machine = os.uname().machine
+    system = os.uname().sysname.lower()
+    arch_map = {"x86_64": "x86_64", "aarch64": "aarch64"}
+    os_map = {"linux": "linux", "darwin": "darwin"}
+    arch = arch_map.get(machine, machine)
+    os_name = os_map.get(system, system)
+    return f"{arch}-{os_name}"
+
+
+def extract_hash(stderr: str) -> str | None:
+    m = re.search(r"got:\s+(sha256-[A-Za-z0-9+/=]+)", stderr)
+    return m.group(1) if m else None
+
+
+def parse_args():
+    root = None
+    check = False
+    args = sys.argv[1:]
+    i = 0
+    while i < len(args):
+        if args[i] == "--root" and i + 1 < len(args):
+            root = Path(args[i + 1])
+            i += 2
+        elif args[i] == "--check":
+            check = True
+            i += 1
+        else:
+            print(f"Unknown argument: {args[i]}", file=sys.stderr)
+            sys.exit(1)
+    return root, check
+
+
+def ensure_repo_root(root: Path, hashes_path: Path):
+    if not hashes_path.exists():
+        print(f"ERROR: {hashes_path} not found", file=sys.stderr)
+        print(f"Is {root} the deepagent-code repo root?", file=sys.stderr)
+        print("Use --root PATH to specify the repo root", file=sys.stderr)
+        sys.exit(1)
+
+
+def build_and_extract(root: Path):
+    result = subprocess.run(
+        ["nix", "build", ".#node_modules_updater", "--no-link", "--print-build-logs"],
+        capture_output=True, text=True, cwd=root,
+    )
+    combined = (result.stdout or "") + (result.stderr or "")
+    return extract_hash(combined)
+
+
+def main():
+    arg_root, check = parse_args()
+    root = arg_root or Path(os.getcwd())
+    hashes_path = root / "nix" / "hashes.json"
+    ensure_repo_root(root, hashes_path)
+
+    platform = get_current_platform()
+
+    if check:
+        data = json.loads(hashes_path.read_text())
+        stored = data["nodeModules"].get(platform)
+        if not stored:
+            print(f"ERROR: no hash stored for platform {platform}", file=sys.stderr)
+            sys.exit(1)
+        actual = build_and_extract(root)
+        if not actual:
+            print("ERROR: could not extract hash from build", file=sys.stderr)
+            sys.exit(2)
+        if stored != actual:
+            print(f"HASH MISMATCH: stored={stored[:30]}... actual={actual[:30]}...", file=sys.stderr)
+            print("Run: nix run .#update-hashes", file=sys.stderr)
+            sys.exit(1)
+        print(f"OK: hash matches for {platform}")
+        return
+
+    print(f"Platform: {platform}")
+    print("Building node_modules_updater to compute correct hash ...")
+    sys.stdout.flush()
+
+    correct = build_and_extract(root)
+    if not correct:
+        print("ERROR: could not extract hash from build output", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Correct hash: {correct}")
+
+    data = json.loads(hashes_path.read_text())
+    old = data["nodeModules"].get(platform, "(missing)")
+    data["nodeModules"][platform] = correct
+    hashes_path.write_text(json.dumps(data, indent=2) + "\n")
+
+    print(f"Updated {platform}: {old} → {correct}")
+    print()
+    print("Done. You can now run: nix build .#deepagent-code")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

`nix/hashes.json` contains pre-computed SHA256 hashes for the `node_modules` fixed-output derivation. These become stale whenever `bun.lock` changes, causing Nix users to hit hash mismatch errors.

The upstream `nix-hashes.yml` CI auto-updates these, but if any of its 4 native runners fail, hashes go stale silently. Fork users and local developers have no easy way to fix hashes.

## Solution

Add a local hash auto-extraction tool:

### `nix run .#update-hashes`
One-command fix for all platforms:

```bash
nix run .#update-hashes              # update current platform
nix run .#update-hashes -- --check   # CI: verify hashes are current
```

### How it works
1. Builds `node_modules_updater` with `lib.fakeHash`
2. Extracts the correct hash from the build error (`got: sha256-...`)
3. Updates `nix/hashes.json` for the current platform

## Changes

| File | Change |
|------|--------|
| `nix/scripts/update-hashes.py` | New: hash extraction script |
| `flake.nix` | Added `apps.update-hashes` |
| `nix/node_modules.nix` | Documentation comment |
| `nix/hashes.json` | Updated `x86_64-linux` hash |

## Testing

- [x] `nix build .#deepagent-code` — clean build
- [x] `nix run .#update-hashes` — correct hash extraction
- [x] `nix run .#update-hashes -- --check` — CI mode passes