### PR TITLE
fix(goal): immediate goal.updated feedback + mode-aware start button

### DIFF
--- a/packages/app/src/components/deepagent/goal-start-button.tsx
+++ b/packages/app/src/components/deepagent/goal-start-button.tsx
@@ -3,9 +3,17 @@ import { Button } from "@deepagent-code/ui/button"
 import { Icon } from "@deepagent-code/ui/icon"
 import { useServerSync } from "@/context/server-sync"
 import { useSDK } from "@/context/sdk"
+import { useLocal } from "@/context/local"
 import { useLanguage } from "@/context/language"
 import { showToast } from "@/utils/toast"
-import { fetchCapabilities, startGoal, type PanelGoalClient } from "./panel-goal.api"
+import { fetchCapabilities, fetchGoalStartable, startGoal, type PanelGoalClient } from "./panel-goal.api"
+
+// The collaboration modes where "convert plan → supervised goal" makes sense. loop/design are BOTH
+// powered by the Goal Loop engine and are designed to have the human START the loop after the plan is
+// authored (loop: agent writes goal+plan.md; design: user writes it). auto is autonomous end-to-end in
+// the current turn — a supervised background goal would be a confusing, redundant second door there, so
+// the button must NOT appear in auto. plan is hidden and never the client-visible current mode.
+const GOAL_MODES = new Set(["loop", "design"])
 
 /**
  * V3.9 §D — "convert plan → goal" starter.
@@ -21,6 +29,7 @@ import { fetchCapabilities, startGoal, type PanelGoalClient } from "./panel-goal
 export function GoalStartButton(props: { sessionID: string }) {
   const sdk = useSDK()
   const serverSync = useServerSync()
+  const local = useLocal()
   const language = useLanguage()
   const [busy, setBusy] = createSignal(false)
 
@@ -32,14 +41,31 @@ export function GoalStartButton(props: { sessionID: string }) {
   )
   const goalAvailable = createMemo(() => capabilities()?.goalLoop === true)
 
-  const plan = createMemo(() => (props.sessionID ? serverSync.data.session_plan[props.sessionID] : undefined))
-  const hasPlan = createMemo(() => (plan()?.steps.length ?? 0) > 0)
+  // The current collaboration mode (auto/loop/design) — the button only applies to loop/design. Sourced
+  // from local.agent.current() (session-scoped mode selection), the same source the mode selector uses.
+  const currentMode = createMemo(() => local.agent.current()?.name)
+  const modeAllows = createMemo(() => GOAL_MODES.has(currentMode() ?? ""))
 
-  // A goal is "live" for this session iff the persistent session_goal pointer exists and is not in a
-  // terminal phase the user has dismissed — while present, GoalStatusBar owns the surface.
+  // A goal is "live" for this session iff the persistent session_goal pointer exists — while present,
+  // GoalStatusBar owns the surface. Checked FIRST so we don't probe startability for an already-running
+  // goal.
   const activeGoal = createMemo(() => (props.sessionID ? serverSync.data.session_goal[props.sessionID] : undefined))
 
-  const show = createMemo(() => goalAvailable() && hasPlan() && !activeGoal())
+  // Whether a plan actually exists to start, resolved server-side (session_plan OR repo goal+plan.md).
+  // Re-fetched when the session, mode-eligibility, active-goal, or the in-session plan changes — the last
+  // dependency makes the button appear promptly after the agent writes a plan mid-conversation. Only
+  // probed when the mode allows and no goal is live, to avoid needless requests.
+  const [startable] = createResource(
+    () =>
+      props.sessionID && goalAvailable() && modeAllows() && !activeGoal()
+        ? ([props.sessionID, serverSync.data.session_plan[props.sessionID]?.steps.length ?? 0] as const)
+        : undefined,
+    ([sessionID]) => fetchGoalStartable(client(), sessionID),
+  )
+
+  const show = createMemo(
+    () => goalAvailable() && modeAllows() && !activeGoal() && startable()?.startable === true,
+  )
 
   const onStart = async () => {
     if (busy() || !props.sessionID) return
@@ -48,8 +74,11 @@ export function GoalStartButton(props: { sessionID: string }) {
       const snapshot = await startGoal(client(), { sessionID: props.sessionID })
       if (!snapshot) {
         showToast({ title: language.t("goal.start.failed") })
+      } else {
+        // The server emits an immediate goal.updated (phase=running) on start, so GoalStatusBar takes
+        // over this surface right away. This toast is the belt-and-suspenders confirmation for the click.
+        showToast({ title: language.t("goal.start.success"), variant: "success" })
       }
-      // On success the goal.updated event drives GoalStatusBar to appear; nothing to do here.
     } catch (err) {
       const description = err instanceof Error ? err.message : String(err)
       showToast({ title: language.t("goal.start.failed"), description })

--- a/packages/app/src/components/deepagent/panel-goal.api.ts
+++ b/packages/app/src/components/deepagent/panel-goal.api.ts
@@ -175,3 +175,26 @@ export const goalStatus = async (
   })
   return response.data?.goal ?? null
 }
+
+export type GoalStartable = { startable: boolean; source: "plan" | "file" | "none" }
+
+/**
+ * Whether a goal can be started for this session right now, resolved SERVER-SIDE with the same plan
+ * precedence start() uses (session_plan → repo goal+plan.md → none). The button gates on this instead
+ * of reading session_plan directly, because loop/design modes author the plan as the repo file (never
+ * touching session_plan), so a client-only hasPlan() check would hide the button in exactly the modes
+ * where it belongs. Tolerant of an older server that lacks the route (treated as not-startable).
+ */
+export const fetchGoalStartable = async (
+  client: PanelGoalClient,
+  sessionID: string,
+): Promise<GoalStartable> => {
+  const response = await client.client.request<GoalStartable>({
+    method: "GET",
+    url: `/deepagent/goal/startable?sessionID=${encodeURIComponent(sessionID)}`,
+  })
+  return {
+    startable: response.data?.startable ?? false,
+    source: response.data?.source ?? "none",
+  }
+}

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -932,6 +932,7 @@ export const dict = {
   "sidebar.wiki": "Repo & Wiki",
   "goal.start.hint": "Plan ready — run it as a supervised goal",
   "goal.start.button": "Run as goal",
+  "goal.start.success": "Goal started — running in the background",
   "goal.start.failed": "Couldn't start the goal",
   "wiki.title": "Repo & Wiki",
   "wiki.description": "Read, search, and govern the four graphs. Knowledge and Memory are editable; Documents and Code are read-only.",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -793,6 +793,7 @@ export const dict = {
   "sidebar.wiki": "仓库与百科",
   "goal.start.hint": "计划已就绪 — 转为受监督的长跑目标",
   "goal.start.button": "转为 Goal",
+  "goal.start.success": "目标已启动，正在后台运行",
   "goal.start.failed": "无法启动目标",
   "wiki.title": "仓库与百科",
   "wiki.description": "阅读、检索、治理四张图。知识与记忆可编辑；文档与代码只读。",

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -646,6 +646,7 @@ export const dict = {
   "review.scope.global": "全域",
   "goal.start.hint": "計劃已就緒 — 轉為受監督的長跑目標",
   "goal.start.button": "轉為 Goal",
+  "goal.start.success": "目標已啟動，正在背景執行",
   "goal.start.failed": "無法啟動目標",
   "wiki.title": "倉庫與百科",
   "wiki.description": "閱讀、檢索、治理四張圖。知識與記憶可編輯；文件與程式碼唯讀。",

--- a/packages/deepagent-code/src/server/routes/instance/httpapi/groups/deepagent.ts
+++ b/packages/deepagent-code/src/server/routes/instance/httpapi/groups/deepagent.ts
@@ -322,6 +322,10 @@ export const DeepAgentGoalSnapshot = Schema.Struct({
 })
 export const DeepAgentGoalStatusResult = Schema.Struct({ goal: Schema.NullOr(DeepAgentGoalSnapshot) })
 export const DeepAgentGoalMutateResult = Schema.Struct({ ok: Schema.Boolean })
+export const DeepAgentGoalStartableResult = Schema.Struct({
+  startable: Schema.Boolean,
+  source: Schema.Literals(["plan", "file", "none"]),
+})
 
 // ── V3.9 §B Repo & Wiki ────────────────────────────────────────────────────
 // The human-facing projection of the four graphs. Read-only browse + governed knowledge edit +
@@ -647,6 +651,13 @@ export const DeepAgentApi = HttpApi.make("deepagent").add(
       HttpApiEndpoint.get("goalStatus", `${root}/goal/status`, {
         query: Schema.Struct({ ...WorkspaceRoutingQueryFields, sessionID: Schema.String }),
         success: described(DeepAgentGoalStatusResult, "The active goal for the session, or null"),
+        error: DeepAgentPromotionError,
+      }),
+    )
+    .add(
+      HttpApiEndpoint.get("goalStartable", `${root}/goal/startable`, {
+        query: Schema.Struct({ ...WorkspaceRoutingQueryFields, sessionID: Schema.String }),
+        success: described(DeepAgentGoalStartableResult, "Whether a goal can be started + plan source"),
         error: DeepAgentPromotionError,
       }),
     )

--- a/packages/deepagent-code/src/server/routes/instance/httpapi/handlers/deepagent.ts
+++ b/packages/deepagent-code/src/server/routes/instance/httpapi/handlers/deepagent.ts
@@ -559,6 +559,9 @@ export const deepagentHandlers = HttpApiBuilder.group(InstanceHttpApi, "deepagen
     const goalStatus = Effect.fn("DeepAgentHttpApi.goalStatus")(function* (ctx) {
       return { goal: yield* goals.status(ctx.query.sessionID) }
     })
+    const goalStartable = Effect.fn("DeepAgentHttpApi.goalStartable")(function* (ctx) {
+      return yield* goals.startable(ctx.query.sessionID)
+    })
 
     // ── V3.9 §B Repo & Wiki ─────────────────────────────────────────────────
     // Read-only projection + governed knowledge edit + full-text search. All fail-closed on the wiki
@@ -679,6 +682,7 @@ export const deepagentHandlers = HttpApiBuilder.group(InstanceHttpApi, "deepagen
       .handle("goalResume", goalResume)
       .handle("goalStop", goalStop)
       .handle("goalStatus", goalStatus)
+      .handle("goalStartable", goalStartable)
       .handle("wikiPages", wikiPages)
       .handle("wikiPage", wikiPage)
       .handle("wikiSearch", wikiSearch)

--- a/packages/deepagent-code/src/session/goal-manager.ts
+++ b/packages/deepagent-code/src/session/goal-manager.ts
@@ -72,6 +72,13 @@ type GoalControl = {
   jobId: string
   paused: boolean
   stopped: boolean
+  // Last-known observable status, cached so pause/resume/stop can publish an IMMEDIATE goal.updated that
+  // carries the real ledger (not zeros). Updated every tick by publishStatus. Without this, a control
+  // transition would either wait for the next tick (pause/resume — slow) or never publish at all (stop
+  // cancels the job, so no further tick fires), leaving the UI status bar stuck on the prior phase.
+  ledger: { ticks: number; tokens: number; cost: number; wallclockMs: number }
+  stallCount: number
+  gaps: readonly string[]
 }
 
 export type StartGoalInput = {
@@ -98,12 +105,23 @@ export type GoalSnapshot = {
   readonly running: boolean
 }
 
+// Whether a goal can be started for a session RIGHT NOW, and where its plan would come from. The client
+// gates the "convert plan → goal" affordance on this instead of guessing from session_plan alone —
+// session_plan is only populated by the plan TOOL, but loop/design modes author the plan as the repo
+// file `.deepagent-code/plans/goal+plan.md`, which start() also accepts. `source` lets the UI phrase
+// the action correctly (existing in-session plan vs the authored repo file).
+export type GoalStartable = {
+  readonly startable: boolean
+  readonly source: "plan" | "file" | "none"
+}
+
 export interface Interface {
   readonly start: (input: StartGoalInput) => Effect.Effect<GoalSnapshot, InvalidGoalError>
   readonly pause: (sessionID: string) => Effect.Effect<boolean>
   readonly resume: (sessionID: string) => Effect.Effect<boolean>
   readonly stop: (sessionID: string) => Effect.Effect<boolean>
   readonly status: (sessionID: string) => Effect.Effect<GoalSnapshot | null>
+  readonly startable: (sessionID: string) => Effect.Effect<GoalStartable>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@deepagent-code/GoalManager") {}
@@ -165,28 +183,85 @@ export const layer = Layer.effect(
         return m
       })
 
-    // Publish a status → both the goal.updated event and the session-state active-goal pointer.
+    // Low-level publisher: emit a goal.updated event over the SSE bridge. Best-effort (ignore) so a
+    // publish failure never crashes the caller (start route or background driver tick).
+    const publishGoalEvent = (
+      sessionID: string,
+      payload: {
+        goalId: string
+        planDocId: string
+        phase: string
+        ledger: { ticks: number; tokens: number; cost: number; wallclockMs: number }
+        stallCount: number
+        gaps: readonly string[]
+      },
+    ) =>
+      events
+        .publish(GoalEvent.Updated, {
+          sessionID: SessionID.make(sessionID),
+          goalId: payload.goalId,
+          planDocId: payload.planDocId,
+          phase: payload.phase,
+          ledger: payload.ledger,
+          stallCount: payload.stallCount,
+          gaps: [...payload.gaps],
+        })
+        .pipe(Effect.ignore)
+
+    // Publish a driver status → the goal.updated event, the session-state active-goal pointer, AND the
+    // cached last-known status on the control (so control transitions can publish the real ledger).
     const publishStatus = (sessionID: string, status: GoalStatus) =>
       Effect.gen(function* () {
         const phase = status.phase as string
         AgentGateway.DeepAgentSessionState.setActiveGoalPhase(sessionID, phase as never)
-        yield* events
-          .publish(GoalEvent.Updated, {
-            sessionID: SessionID.make(sessionID),
-            goalId: status.goalId,
-            planDocId: status.planDocId,
-            phase,
-            ledger: {
-              ticks: status.ledger.ticks,
-              tokens: status.ledger.tokens,
-              cost: status.ledger.cost,
-              wallclockMs: status.ledger.wallclockMs,
-            },
-            stallCount: status.stallCount,
-            gaps: status.gaps,
-          })
-          .pipe(Effect.ignore)
+        const ledger = {
+          ticks: status.ledger.ticks,
+          tokens: status.ledger.tokens,
+          cost: status.ledger.cost,
+          wallclockMs: status.ledger.wallclockMs,
+        }
+        yield* mutateControl(sessionID, (ctrl) => {
+          ctrl.ledger = ledger
+          ctrl.stallCount = status.stallCount
+          ctrl.gaps = status.gaps
+        })
+        yield* publishGoalEvent(sessionID, {
+          goalId: status.goalId,
+          planDocId: status.planDocId,
+          phase,
+          ledger,
+          stallCount: status.stallCount,
+          gaps: status.gaps,
+        })
       })
+
+    // Publish an IMMEDIATE goal.updated for a control transition (pause/resume/stop). Reuses the control's
+    // cached ledger/stall/gaps so the UI keeps its live budget readout while only the phase changes.
+    const publishControlPhase = (sessionID: string, control: GoalControl, phase: string) =>
+      publishGoalEvent(sessionID, {
+        goalId: control.goalId,
+        planDocId: control.planDocId,
+        phase,
+        ledger: control.ledger,
+        stallCount: control.stallCount,
+        gaps: control.gaps,
+      })
+
+    // Reflect a driver's terminal outcome into the active-goal pointer — but ONLY if the goal is still
+    // controlled. A user `stop()` clears the control (setControl null) and has already set the pointer to
+    // "stopped" and published it; the cancelled driver may still settle with its own outcome (e.g. it
+    // observed shouldStop and returned "needs_human") whose late tap would otherwise clobber "stopped".
+    // Guarding on a live control makes the explicit stop authoritative and drops the racing outcome.
+    const finalizeOutcome = (sessionID: string, outcome: string) =>
+      getControl(sessionID).pipe(
+        Effect.flatMap((c) =>
+          Effect.sync(() => {
+            if (outcome !== "continue" && c != null) {
+              AgentGateway.DeepAgentSessionState.setActiveGoalPhase(sessionID, outcome as never)
+            }
+          }),
+        ),
+      )
 
     const start: Interface["start"] = (input) =>
       Effect.gen(function* () {
@@ -278,6 +353,20 @@ export const layer = Layer.effect(
           startedAt: new Date().toISOString(),
         })
 
+        // Emit an IMMEDIATE goal.updated (phase=running, empty ledger) BEFORE the first tick. The first
+        // driver tick is a full subagent turn (tens of seconds), and onStatus only fires AFTER it — so
+        // without this, the client's session_goal store stays empty and the "convert plan → goal" hint
+        // never flips to the GoalStatusBar, leaving the user with no confirmation the goal started. This
+        // seeds the store the moment start returns, so the UI reflects the running goal instantly.
+        yield* publishGoalEvent(sessionID, {
+          goalId: handle.goalId,
+          planDocId: handle.planDocId,
+          phase: "running",
+          ledger: { ticks: 0, tokens: 0, cost: 0, wallclockMs: 0 },
+          stallCount: 0,
+          gaps: [],
+        })
+
         // The driver ports read the per-session control flags (pause/stop) live.
         const ports: GoalDriverPorts = {
           onStatus: (status) => publishStatus(sessionID, status),
@@ -291,15 +380,9 @@ export const layer = Layer.effect(
           title: `goal ${handle.goalId}`,
           metadata: { sessionID, goalId: handle.goalId },
           run: GoalDriver.runToCompletion({ deps, handle, ports }).pipe(
-            Effect.tap((outcome) =>
-              Effect.sync(() => {
-                // A terminal outcome clears the running pointer to its terminal phase; a paused exit
-                // leaves the pointer for a later resume.
-                if (outcome !== "continue") {
-                  AgentGateway.DeepAgentSessionState.setActiveGoalPhase(sessionID, outcome as never)
-                }
-              }),
-            ),
+            // A terminal outcome clears the running pointer to its terminal phase (unless the user already
+            // stopped it); a paused exit ("continue") leaves the pointer for a later resume.
+            Effect.tap((outcome) => finalizeOutcome(sessionID, outcome)),
             Effect.map((outcome) => `goal ${handle.goalId}: ${outcome}`),
             Effect.catchCause(() => Effect.succeed(`goal ${handle.goalId}: driver defect`)),
           ),
@@ -311,6 +394,9 @@ export const layer = Layer.effect(
           jobId: job.id,
           paused: false,
           stopped: false,
+          ledger: { ticks: 0, tokens: 0, cost: 0, wallclockMs: 0 },
+          stallCount: 0,
+          gaps: [],
         })
 
         return { goalId: handle.goalId, planDocId: handle.planDocId, phase: "running", running: true }
@@ -322,6 +408,8 @@ export const layer = Layer.effect(
         if (!c) return false
         yield* mutateControl(sessionID, (ctrl) => (ctrl.paused = true))
         AgentGateway.DeepAgentSessionState.setActiveGoalPhase(sessionID, "paused")
+        // Immediate goal.updated so the status bar flips to "paused" now, not after the in-flight tick.
+        yield* publishControlPhase(sessionID, c, "paused")
         return true
       })
 
@@ -364,17 +452,15 @@ export const layer = Layer.effect(
           title: `goal ${c.goalId} (resumed)`,
           metadata: { sessionID, goalId: c.goalId },
           run: GoalDriver.runToCompletion({ deps, handle, ports }).pipe(
-            Effect.tap((outcome) =>
-              Effect.sync(() => {
-                if (outcome !== "continue")
-                  AgentGateway.DeepAgentSessionState.setActiveGoalPhase(sessionID, outcome as never)
-              }),
-            ),
+            Effect.tap((outcome) => finalizeOutcome(sessionID, outcome)),
             Effect.map((outcome) => `goal ${c.goalId}: ${outcome}`),
             Effect.catchCause(() => Effect.succeed(`goal ${c.goalId}: driver defect`)),
           ),
         })
         yield* mutateControl(sessionID, (ctrl) => (ctrl.jobId = job.id))
+        // Immediate goal.updated so the status bar flips back to "running" now. The resumed driver's
+        // first tick may be tens of seconds away; without this the bar would stay stuck on "paused".
+        yield* publishControlPhase(sessionID, c, "running")
         return true
       })
 
@@ -386,6 +472,10 @@ export const layer = Layer.effect(
         yield* background.cancel(c.jobId).pipe(Effect.ignore)
         AgentGateway.DeepAgentSessionState.setActiveGoalPhase(sessionID, "stopped")
         yield* setControl(sessionID, null)
+        // Immediate goal.updated is MANDATORY here: cancelling the job means no further tick will ever
+        // fire onStatus, so this is the ONLY event that can move the status bar off its prior phase.
+        // Without it the UI is stuck showing "running" forever after the user hits stop.
+        yield* publishControlPhase(sessionID, c, "stopped")
         return true
       })
 
@@ -402,11 +492,23 @@ export const layer = Layer.effect(
         }
       })
 
-    // Reference `flags` so an unused-var lint stays quiet; the real gate is makeGoalLoopWiring returning
-    // null when experimentalGoalLoop is off (checked in start/resume).
-    void flags
+    // Whether start() would find a plan to run — mirrors its plan-resolution precedence WITHOUT side
+    // effects (no doc materialized, no driver started). Flag-gated: a disabled goal loop is never
+    // startable. session_plan (loop-tool authored) wins; else the repo goal+plan.md (loop/design file);
+    // else none. Used by the client to gate the convert-to-goal affordance in the modes where it applies.
+    const startable: Interface["startable"] = (sessionID) =>
+      Effect.gen(function* () {
+        if (!flags.experimentalGoalLoop) return { startable: false, source: "none" as const }
+        const existing = AgentGateway.DeepAgentSessionState.getPlan(sessionID) as PlanDoc | null
+        if (existing != null) return { startable: true, source: "plan" as const }
+        const session = yield* sessions.get(SessionID.make(sessionID)).pipe(Effect.orDie)
+        const cwd = session.directory ?? process.cwd()
+        const fromFile = readGoalPlanFile(cwd, sessionID)
+        if (fromFile?.plan != null) return { startable: true, source: "file" as const }
+        return { startable: false, source: "none" as const }
+      })
 
-    return Service.of({ start, pause, resume, stop, status })
+    return Service.of({ start, pause, resume, stop, status, startable })
   }),
 )
 


### PR DESCRIPTION
Goal Loop control changes updated in-memory state but emitted no immediate goal.updated event, so the client status bar never reflected them until the next tick (a full subagent turn). stop() was worst: it cancels the driver job, so no further tick ever fires and the UI stayed stuck on "running" forever.

- goal-manager: extract publishGoalEvent + publishControlPhase; cache the live ledger/stall/gaps on GoalControl (updated each tick) so control transitions publish the real budget, not zeros.
- start/pause/resume/stop now emit an immediate goal.updated.
- finalizeOutcome guards the driver's terminal tap on a live control so a cancelled driver's late "needs_human" outcome cannot clobber the user's explicit "stopped".

The "convert plan -> goal" button gated on session_plan, which only the plan tool populates — but loop/design modes author the plan as the repo file goal+plan.md, so the button never appeared in the modes it belongs to and did appear in auto (redundant/confusing).

- New GoalManager.startable() mirrors start()'s plan precedence (session_plan -> goal+plan.md -> none) without side effects, flag-gated.
- New GET /deepagent/goal/startable route + handler.
- Button now gates on capability x mode in {loop,design} x startable, and shows a success toast on start. i18n goal.start.success (en/zh/zht).

### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Please provide a description of the issue, the changes you made to fix it, and why they work. It is expected that you understand why your changes work and if you do not understand why at least say as much so a maintainer knows how much to value the PR.

**If you paste a large clearly AI generated description here your PR may be IGNORED or CLOSED!**

### How did you verify your code works?

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [ ] I have tested my changes locally
- [ ] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
