### PR TITLE
chore(desktop): prepare 1.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Fix Plan Gate deadlock: stale-plan latch now warns (never hard-blocks) on tool execution, aligned with codex exec-policy philosophy. A mutating tool on a stale plan receives a reminder but always runs.
 - Fix goal-loop scorer false positives: `extractValidationResults` now scopes extraction to declared validation commands only (toolCallId→command mapping), with latest-wins per command. Diagnostic bash calls no longer poison the score.
 - Fix cancel/loop test flake: `maxRetries:0` in the test provider config prevents AI SDK exponential-backoff retries against the intentionally-dead test URL; per-test budgets raised from 3 s to 15 s.
-- Bump desktop app to 1.4.2.
+- Release Desktop 1.4.2 with DeepAgent Core V4.0.4.
 - Publishing truth: fix quick-start command (`deepagent-code run`), comment out unpublished npm install, unify domain to `deepagent.ltd`, replace `lessweb`/`anomalyco` org handles, update SECURITY.md supported-version line and M-CRED status, update CHANGELOG.
 
 ## V4.0.3 - Upstream kernel alignment (AppNode foundation)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://github.com/deepagent-ltd/deepagent-code-enterprise">Enterprise</a>
 </p>
 
-<p align="center"><sub>Desktop 1.4.2 · DeepAgent Core V4.0</sub></p>
+<p align="center"><sub>Desktop 1.4.2 · DeepAgent Core V4.0.4</sub></p>
 
 ---
 
@@ -91,17 +91,16 @@ For high-risk decisions, convene an **Expert Panel**. Correctness, security, per
 
 Project IM brings people and agents into the same thread. Mention an agent to start a scoped run with project context, stream its progress, inspect its artifacts, and keep the answer attached to the conversation that requested it.
 
-## DeepAgent Core V4.1
+## DeepAgent Core V4.0.4
 
-V4.1 brings the complete DeepAgent control plane together:
+V4.0.4 closes production contract gaps while keeping the current turn engine stable:
 
-- **Durable Session V2:** prompt admission is persisted before execution; exact retries do not duplicate user intent; same-session wakes coalesce safely.
-- **One provider-turn contract:** native and AI SDK providers share the same budget, permission, artifact, audit, learning, and close lifecycle.
-- **Single durable truth:** DocumentStore owns documents, plans, learning candidates, governance state, and version conflicts through atomic, recoverable writes.
-- **Event-driven Agent OS:** durable events, priority routing, backpressure, worker claims, leases, handoffs, retries, dead-letter recovery, and distributed placement coordinate autonomous work.
-- **Consumer-driven goals:** `goal.tick.requested` claims and executes one idempotent tick, records facts, and schedules the next tick only when the durable goal remains eligible.
-- **Human oversight:** approval queues, trace correlation, takeover, rollback, Wiki archives, notifications, and organization/workspace isolation remain part of the execution path.
-- **Secure integrations:** MCP credentials use environment references or native OS secret storage; catalog risk, runtime permissions, trusted sources, and tool capability checks fail closed.
+- **Single durable truth:** DocumentStore uses atomic, recoverable writes for documents, plans, learning candidates, governance state, and version conflicts.
+- **Isolated subagents:** write-capable subagents use dedicated worktrees by default and return their changes to the parent workspace through a bounded, conflict-aware path.
+- **Reliable event delivery:** the Event Bus has a transport seam, durable consumer offsets, offline catch-up, real priority ordering, and observable queue depth.
+- **Governed learning and goals:** knowledge promotion is tied to review evidence and ship-gate snapshots; event-driven goal ticks remain idempotent and respect quiet hours.
+- **Secure integrations:** MCP credentials use environment references or native OS secret storage on macOS, Linux, and Windows; capability and source checks fail closed.
+- **Publishing truth:** installation, CLI examples, release metadata, public domains, and supported-version documentation match the product that is actually shipped.
 
 ## Installation
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -14,7 +14,7 @@
   <a href="https://github.com/deepagent-ltd/deepagent-code-enterprise">Enterprise 版本</a>
 </p>
 
-<p align="center"><sub>桌面版 1.4.1 · DeepAgent Core V4.1</sub></p>
+<p align="center"><sub>桌面版 1.4.2 · DeepAgent Core V4.0.4</sub></p>
 
 ---
 
@@ -91,22 +91,25 @@ DeepAgent 可以把独立工作拆分给数量有界、相互隔离的 Worker。
 
 项目 IM 把团队成员和智能体放进同一条讨论。@ 某个智能体即可启动有明确作用域的运行，使用项目上下文、流式展示进度、关联执行工件，并把答案留在发起任务的对话里。
 
-## DeepAgent Core V4.1
+## DeepAgent Core V4.0.4
 
-V4.1 把完整的 DeepAgent 控制平面汇聚在一起：
+V4.0.4 在保持当前 turn 引擎稳定的前提下，关闭生产合同缺口：
 
-- **持久 Session V2：** prompt 先持久准入、再调度执行；精确重试不会复制用户意图；同一 Session 的唤醒会安全合并。
-- **统一供应商轮次合同：** native 与 AI SDK provider 共享预算、权限、工件、审计、学习和关闭生命周期。
 - **单一持久真相：** DocumentStore 通过原子、可恢复写入统一管理文档、计划、学习候选、治理状态和版本冲突。
-- **事件驱动 Agent OS：** 持久事件、优先级路由、回压、Worker claim、租约、handoff、重试、死信恢复与分布式 placement 协调自主工作。
-- **消费者驱动 Goal：** `goal.tick.requested` 每次认领并执行一个幂等 tick，记录事实，并只在持久目标仍满足条件时调度下一 tick。
-- **人类监督：** 审批队列、全链路 trace、接管、回滚、Wiki 档案、通知，以及组织和 workspace 隔离始终位于执行路径上。
-- **安全集成：** MCP 凭据使用环境变量引用或原生操作系统 secret storage；目录风险、运行时权限、可信来源和工具 capability 逐层失败关闭。
+- **隔离子智能体：** 具备写权限的子智能体默认使用独立 worktree，并通过有界、可感知冲突的路径把改动回传到父工作区。
+- **可靠事件投递：** Event Bus 提供可替换 transport、持久 consumer offset、离线补投、真实优先级排序和可观测队列深度。
+- **受治理的学习与目标：** 知识晋升关联审阅证据与 ship-gate snapshot；事件驱动 goal tick 保持幂等并遵守 quiet hours。
+- **安全集成：** MCP 凭据使用环境变量引用或 macOS、Linux、Windows 原生 secret storage；capability 与来源检查逐层失败关闭。
+- **发布真实性：** 安装方式、CLI 示例、发布元数据、公开域名和支持版本文档与实际交付产品一致。
 
 ## 安装
 
+> **说明：** `deepagent-code` npm 包尚未公开发布。
+> 请通过桌面应用或下面的安装脚本安装。
+
 ```bash
-npm install -g deepagent-code
+# 安装脚本（macOS / Linux）
+curl -fsSL https://deepagent.ltd/install | bash
 ```
 
 然后运行：
@@ -178,7 +181,7 @@ deepagent auth list
 启动智能体并交给它一个任务：
 
 ```bash
-deepagent-code "为 /api/users 端点添加限流"
+deepagent-code run "为 /api/users 端点添加限流"
 ```
 
 智能体将会：

--- a/bun.lock
+++ b/bun.lock
@@ -349,7 +349,7 @@
     },
     "packages/desktop": {
       "name": "@deepagent-code/desktop",
-      "version": "1.2.0",
+      "version": "1.4.2",
       "dependencies": {
         "@zip.js/zip.js": "2.7.62",
         "effect": "catalog:",

--- a/design/README.md
+++ b/design/README.md
@@ -1,6 +1,6 @@
 # DeepAgent Code — Architecture & Design
 
-> **Public design overview.** Internal implementation details and roadmap docs live in the private `docs/` tree (not version-controlled). This directory contains the publicly visible architectural narrative.
+> **Public design overview for DeepAgent Core V4.0.4 / Desktop 1.4.2.** Internal implementation details and roadmap documents live in the private `docs/` tree and are intentionally not version-controlled.
 
 ---
 
@@ -8,13 +8,13 @@
 
 DeepAgent Code is an AI coding agent that adds a **control plane** on top of the [opencode](https://github.com/sst/opencode) runtime. It keeps the proven opencode foundations (runtime, tool, MCP, session, provider stack) and layers in:
 
-- **Durable document memory** — knowledge base with retrieval gates, dedup, and merge
-- **Context assembly** — selective, evidence-backed context building (not raw file dumps)
-- **Plan system** — structured task planning with staleness detection and rollback
-- **Failure triage** — three-tier classifier (auto-fixable / needs-narrowing / not-auto-fixable)
-- **Domain adapters** — pluggable domain packs for specialized workflows
+- **Durable document and project memory** — atomic, recoverable storage with retrieval gates, provenance, governance, and conflict detection
+- **Connected context** — selective, evidence-backed assembly across code, knowledge, project memory, and execution documents
+- **Plans and long-running goals** — structured plans, stale-state detection, validation evidence, bounded retries, and human control
+- **Event-driven coordination** — durable delivery, priority routing, offline catch-up, idempotent goal ticks, and observable queue state
+- **Isolated agent collaboration** — bounded subagents, worktree isolation for write-capable workers, and conflict-aware change return
 - **AI IDE microservice** — LSP-backed semantic code navigation via `code_intel`
-- **MCP catalog** — curated, one-click-enable MCP servers with safety tiers
+- **Secure MCP catalog** — curated integrations, derived safety tiers, environment references, and native OS secret storage
 
 ---
 
@@ -22,11 +22,11 @@ DeepAgent Code is an AI coding agent that adds a **control plane** on top of the
 
 ### 1. Enhance, don't replace
 
-DeepAgent is built **on top of** the opencode agent/runtime/session/tool/MCP stack. It does not rewrite the execution engine, tool system, or provider layer. The default agent behavior is not degraded. The lower-strength `general` mode stays close to the inherited runtime contract.
+DeepAgent is built **on top of** the opencode agent/runtime/session/tool/MCP stack. V4.0.4 strengthens the control plane without replacing the current turn engine, tool system, or provider layer.
 
-### 2. Control-plane only
+### 2. One durable authority per concern
 
-DeepAgent is responsible for **strategy / context / budget / audit / verification / document graph**. It does not directly spawn LSP processes or execute MCP tools — those go through the existing `LSP.Service` and `MCP.Service` respectively.
+Documents, plans, event delivery state, knowledge promotion, and goal progress each have one authoritative durable store. In-memory state may accelerate delivery, but it cannot become a second source of truth.
 
 ### 3. Full tool output does not enter context
 
@@ -36,6 +36,10 @@ Per the deterministic task control contract: raw LSP results, diagnostic dumps, 
 
 MCP catalog entries default to **not connected** (zero startup overhead). Dangerous write operations (force-push, DROP, file delete) require explicit approval. Read-only DB connections enforce restricted-mode at the server level.
 
+### 5. Keep execution boundaries explicit
+
+Write-capable subagents run in isolated worktrees by default. Event consumers claim durable work with idempotency and retry boundaries. Users retain explicit paths to approve, steer, pause, resume, take over, or roll back long-running work.
+
 ---
 
 ## Component Map
@@ -44,24 +48,23 @@ MCP catalog entries default to **not connected** (zero startup overhead). Danger
 ┌─────────────────────────────────────────────────────────────┐
 │  DeepAgent Control Plane                                    │
 │                                                             │
-│  ┌──────────────┐  ┌─────────────┐  ┌───────────────────┐  │
-│  │  Plan System │  │  Doc Memory │  │  Failure Triage   │  │
-│  │  (task/plan) │  │  (knowledge │  │  (3-tier classify)│  │
-│  └──────┬───────┘  │   store)    │  └─────────┬─────────┘  │
-│         │          └──────┬──────┘            │             │
-│  ┌──────▼──────────────────▼──────────────────▼───────────┐  │
-│  │            Agent Gateway (core)                        │  │
-│  │  audit · budget · permission · capability index        │  │
-│  └──────┬─────────────────────────────────────────────────┘  │
-└─────────│───────────────────────────────────────────────────┘
-          │
-┌─────────▼──────────────────────────────────────────────────┐
-│  opencode Foundation (unchanged)                           │
-│                                                            │
-│  Session ─── Tool Registry ─── MCP Service                │
-│     │              │                  │                    │
-│  Provider       LSP Service      38 lang servers           │
-│  (Claude/…)   code_intel tool    + MCP catalog             │
+│  DocumentStore ─ Plan/Goal ─ Knowledge Governance          │
+│       │              │                │                     │
+│  Context Graph ─ Event Bus ─ Oversight and Audit           │
+│       │              │                │                     │
+│  ┌────▼──────────────▼────────────────▼──────────────────┐  │
+│  │ Agent Gateway: budget · permission · evidence · policy│  │
+│  └────┬───────────────────────────────────────────────────┘  │
+└───────│─────────────────────────────────────────────────────┘
+        │
+┌───────▼────────────────────────────────────────────────────┐
+│  opencode Foundation                                       │
+│  Session · Provider · Tool Registry · LSP · MCP            │
+└────────────────────────────────────────────────────────────┘
+        │
+┌───────▼────────────────────────────────────────────────────┐
+│  Execution Boundaries                                      │
+│  isolated subagents · worktrees · event consumers · tools  │
 └────────────────────────────────────────────────────────────┘
 ```
 
@@ -93,9 +96,7 @@ Each catalog entry carries a **risk tier** derived at load time from the catalog
 | `write_guarded` | filesystem, github, git | Write ops require explicit approval |
 | `external_fetch` | fetch, browser (Playwright) | External requests require explicit approval |
 
-**Credentials** are declared by key name in the catalog template (`CredentialSpec`). Values are filled at enable-time.
-
-> **Known limitation (V3.4):** credential values are stored in plaintext in the local config file. Do not commit config files containing credentials to version control. A secure-storage mechanism (OS keyring, aligned with the codex approach) is planned for V3.5.
+**Credentials** are declared by key name in the catalog template (`CredentialSpec`). Configuration stores environment references or `secret://` handles instead of plaintext values. Handles resolve at connection time through macOS Keychain, Linux Secret Service (`libsecret`), or Windows DPAPI-backed credential storage.
 
 ---
 
@@ -103,18 +104,20 @@ Each catalog entry carries a **risk tier** derived at load time from the catalog
 
 | Mechanism | Status |
 |-----------|--------|
-| MCP risk tier — catalog-derived, not config-injectable | ✅ V3.4 |
-| MCP catalog defaults to not connected | ✅ V3.4 |
-| Dangerous writes: approval gate (`ctx.ask`) | ✅ V3.4 |
-| Read-only DB: restricted-mode enforced at server | ✅ V3.4 |
-| Credential secure storage (OS keyring) | ⏳ V3.5 M-CRED |
+| MCP risk tier — catalog-derived, not config-injectable | Available |
+| MCP catalog defaults to not connected | Available |
+| Dangerous writes: approval gate (`ctx.ask`) | Available |
+| Read-only DB: restricted mode enforced at server | Available |
+| Credential indirection (`${VAR}` / `secret://`) | Available |
+| Native secret storage (macOS / Linux / Windows) | Available in V4.0.4 |
+| Subagent write isolation and conflict-aware return | Available in V4.0.4 |
 
 ---
 
 ## License
 
 DeepAgent Code is licensed under **AGPL-3.0-or-later**.
-Source code: [github.com/lessweb/deepagent-code](https://github.com/lessweb/deepagent-code)
+Source code: [github.com/deepagent-ltd/deepagent-code](https://github.com/deepagent-ltd/deepagent-code)
 
 DeepAgent Code is derived from [opencode](https://github.com/sst/opencode) (MIT).
 See `NOTICE` in the repository root for the full upstream attribution.

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@deepagent-code/desktop",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.4.2",
   "type": "module",
   "license": "AGPL-3.0-or-later",
   "homepage": "https://deepagent-code.ai",


### PR DESCRIPTION
## Summary

- set the Desktop package and workspace lock version to 1.4.2
- align the public English, Chinese, and design documentation to DeepAgent Core V4.0.4
- correct the Chinese installation and quick-start commands

## Verification

- `bun typecheck` in `packages/desktop`
- `bun test src/main/updater-controller.test.ts src/main/updater-subscriptions.test.ts` in `packages/desktop` (8 passed)
- repository pre-push `bun turbo typecheck` (15 packages passed)
- release-version consistency assertions and `git diff --check`

## Release behavior

A subsequent push of the integrated release commit to `main` will let `desktop-build.yml` publish `app-v1.4.2-main.<run>` as the latest updater release.