### PR TITLE
test(core): await debounced sessions.json flush in plan-store test

### DIFF
--- a/packages/core/test/deepagent/plan-store.test.ts
+++ b/packages/core/test/deepagent/plan-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test"
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs"
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import path from "node:path"
 import * as PlanStore from "../../src/deepagent/plan-store"
@@ -65,17 +65,20 @@ describe("I33-1 plan-store single authority", () => {
     expect(PlanStore.getPlanDoc("s2")?.steps[0].status).toBe("done")
   })
 
-  test("session-state.setPlan/getPlan delegate to the store (body NOT on session state)", () => {
+  test("session-state.setPlan/getPlan delegate to the store (body NOT on session state)", async () => {
     SessionState.getOrCreate("s3", "high")
     const p = plan("s3", [step("step_1")])
     SessionState.setPlan("s3", p)
+    // saveToDisk() is debounced via setImmediate (PERF, c0b79979): yield one event-loop turn so
+    // flushToDisk lands sessions.json before the synchronous read below.
+    await new Promise((resolve) => setImmediate(resolve))
     // readable via session-state (delegates to plan-store) AND directly from plan-store (same doc)
     expect(SessionState.getPlan("s3")?.goal).toBe("goal s3")
     expect(PlanStore.getPlanDoc("s3")?.goal).toBe("goal s3")
     // the latch pointer is bound to the plan id (the hot-path value object that STAYS on session state)
     expect(SessionState.planLatch("s3")?.plan_id).toBe(p.plan_id)
     // the persisted sessions.json must NOT carry the plan body (authority moved to the store)
-    const raw = require("node:fs").readFileSync(path.join(stateDir, "sessions.json"), "utf8")
+    const raw = readFileSync(path.join(stateDir, "sessions.json"), "utf8")
     expect(JSON.parse(raw)["s3"].plan).toBeUndefined()
   })
 


### PR DESCRIPTION
   ### Issue for this PR

   Closes #

   (no tracking issue — this fixes the `unit (macos)` CI failure seen on #89)

   ### Type of change

   - [x] Bug fix
   - [ ] New feature
   - [ ] Refactor / code improvement
   - [ ] Documentation

   ### What does this PR do?

   `c0b79979` ("perf(core): 修复启动慢根因 — sessions.json 防抖") changed `session-state.ts` `saveToDisk()` from a synchronous write to a debounced
 `setImmediate(flushToDisk)`. The I33-1 plan-store test (`packages/core/test/deepagent/plan-store.test.ts`) predates that change and still assumed synchronous
 persistence:

   ```ts
   SessionState.setPlan("s3", p)   // only schedules setImmediate(flushToDisk), nothing on disk yet
   const raw = readFileSync(path.join(stateDir, "sessions.json"), "utf8")  // ENOENT
 ```

 The test body is fully synchronous, so whether the file exists at read time depends on event-loop timing — on the macOS runner it consistently fails with
 ENOENT, which is what failed unit (macos) (@deepagent-code/core#test:ci exit 1) on #89. The linux/windows jobs in that run were cancelled (fail-fast) before
 executing, so this is not actually macOS-specific.

 Fix: make the test async and yield one event-loop turn (await new Promise((resolve) => setImmediate(resolve))) after setPlan, so the debounced flushToDisk lands
 sessions.json before the assertion reads it. No production code changes. I also replaced the inline require("node:fs").readFileSync with the top-level
 readFileSync import.

 I verified the root cause by checking out c0b79979^ in a worktree: the test passes there and fails at dev HEAD, so the debounce commit is what broke it.

 ### How did you verify your code works?

 - cd packages/core && bun test test/deepagent/plan-store.test.ts → 8 pass / 0 fail (previously 7 pass / 1 fail with ENOENT)
 - Full package suite bun test (2236 tests / 225 files): this test was the only failure before the fix
 - bun run typecheck in packages/core passes

 ### Screenshots / recordings

 If this is a UI change, please include a screenshot or recording.

 N/A — test-only change.

 ### Checklist

 - [x] I have tested my changes locally
 - [x] I have not included unrelated changes in this PR